### PR TITLE
Refactor wilder#result

### DIFF
--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -131,7 +131,7 @@ endfunction
 
 function! wilder#result_output_escape(chars) abort
   return wilder#result({
-        \'output': {ctx, x, prev -> escape(prev(ctx, x), a:chars)},
+        \'output': [{ctx, x -> escape(x, a:chars)}],
         \ })
 endfunction
 

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -601,7 +601,7 @@ function! wilder#cmdline#get_user_completion(cmdline) abort
   return v:false
 endfunction
 
-function! wilder#cmdline#replace(ctx, x, prev) abort
+function! wilder#cmdline#replace(ctx, x) abort
   let l:result = wilder#cmdline#parse(a:ctx.cmdline)
 
   if l:result.pos == 0
@@ -621,7 +621,7 @@ function! wilder#cmdline#replace(ctx, x, prev) abort
   return l:result.cmdline[: l:result.pos - 1] . a:x
 endfunction
 
-function! wilder#cmdline#draw_path(ctx, x, prev) abort
+function! wilder#cmdline#draw_path(ctx, x) abort
   if has_key(a:ctx, 'meta') &&
         \ type(a:ctx.meta) is v:t_dict &&
         \ has_key(a:ctx.meta, 'path_prefix')
@@ -635,7 +635,7 @@ function! wilder#cmdline#draw_path(ctx, x, prev) abort
     return a:x[l:i :]
   endif
 
-  return a:prev(a:ctx, a:x, a:x)
+  return a:x
 endfunction
 
 function! wilder#cmdline#user_completion_pipeline() abort
@@ -644,7 +644,7 @@ function! wilder#cmdline#user_completion_pipeline() abort
       \ {_, x -> wilder#cmdline#parse(x)},
       \ wilder#check({_, res -> wilder#cmdline#is_user_command(res.cmd)}),
       \ {_, res -> wilder#cmdline#get_user_completion(res.cmdline)},
-      \ wilder#result({'replace': funcref('wilder#cmdline#replace')}),
+      \ wilder#result({'replace': ['wilder#cmdline#replace']}),
       \ ]
 endfunction
 
@@ -671,7 +671,7 @@ function! wilder#cmdline#getcompletion_pipeline(opts) abort
       \ (l:fuzzy ? [wilder#cmdline#make_filter(l:Matcher)] : [])
       \ + [
       \ l:fuzzy ? wilder#cmdline#make_filter(l:Matcher) : {_, x -> x},
-      \ wilder#result({'replace': funcref('wilder#cmdline#replace')}),
+      \ wilder#result({'replace': ['wilder#cmdline#replace']}),
       \ ]
 endfunction
 
@@ -701,10 +701,10 @@ function! wilder#cmdline#get_file_completion_pipeline(opts) abort
       \ (l:fuzzy ? [wilder#cmdline#make_filter(l:Matcher)] : [])
       \ + [
       \ wilder#result({
-      \   'meta': {ctx, meta -> extend(meta, {'path_prefix': ctx.path_prefix})},
-      \   'output': {_, x -> escape(x, ' ')},
-      \   'draw': funcref('wilder#cmdline#draw_path'),
-      \   'replace': funcref('wilder#cmdline#replace'),
+      \   'meta': {ctx, meta -> extend(meta is v:null ? {} : meta, {'path_prefix': ctx.path_prefix})},
+      \   'output': [{_, x -> escape(x, ' ')}],
+      \   'draw': ['wilder#cmdline#draw_path'],
+      \   'replace': ['wilder#cmdline#replace'],
       \ }),
       \ ]
 endfunction
@@ -766,7 +766,7 @@ function! wilder#cmdline#substitute_pipeline(opts) abort
       \ {_, res -> wilder#cmdline#substitute#parse({'cmdline': res.cmdline[res.pos :], 'pos': 0})},
       \ {_, res -> len(res) == 2 ? res[1] : (l:hide_in_replace ? v:true : v:false)},
       \ ] + l:pipeline + [
-      \ wilder#result({'replace': funcref('wilder#cmdline#replace')}),
+      \ wilder#result({'replace': ['wilder#cmdline#replace']}),
       \ ]
 endfunction
 

--- a/autoload/wilder/pipeline/component/result.vim
+++ b/autoload/wilder/pipeline/component/result.vim
@@ -1,54 +1,26 @@
 function! wilder#pipeline#component#result#make(...) abort
   let l:args = a:0 ? a:1 : {}
-  return {ctx, xs -> map(xs, {_, x -> s:result(l:args, ctx, x)})}
+  return {ctx, xs -> s:result(l:args, ctx, xs)}
 endfunction
 
-function! s:result(args, ctx, x) abort
-  let l:x = type(a:x) is v:t_string ? {'value': a:x} : a:x
+function! s:result(args, ctx, xs) abort
+  let l:result = type(a:xs) isnot v:t_dict ?
+        \ {'xs': a:xs} :
+        \ a:xs
 
   for l:key in keys(a:args)
     let l:F = a:args[l:key]
 
-    if l:key ==# 'value'
-      if type(l:F) is v:t_func
-        let l:x.value = l:F(a:ctx, l:x.value)
-      else
-        let l:x.value = l:F
-      endif
-      continue
-    elseif l:key ==# 'meta'
-      if type(l:F) is v:t_func
-        let l:x.meta = l:F(a:ctx, get(l:x, 'meta', {}))
-      else
-        let l:x.meta = extend(get(l:x, 'meta', {}), a:args.meta)
-      endif
-      continue
-    endif
-
-    if has_key(l:x, l:key)
-      if type(l:x[l:key]) is v:t_func
-        let l:Prev = l:x[l:key]
-      else
-        let l:Prev = {ctx, x, def -> l:x[l:key]}
-      endif
+    if type(l:F) is v:t_list
+      let l:result[l:key] = get(l:result, l:key, []) + l:F
+    elseif type(l:F) is v:t_dict
+      let l:result[l:key] = extend(get(l:result, l:key, {}), l:F)
+    elseif type(l:F) is v:t_func
+      let l:result[l:key] = l:F(a:ctx, get(l:result, l:key, v:null))
     else
-      let l:Prev = {ctx, x, def -> def}
+      let l:result[l:key] = l:F
     endif
-
-    let l:x[l:key] = s:make_func(l:F, l:Prev)
   endfor
 
-  return l:x
-endfunction
-
-function! s:make_func(f, prev) abort
-  return {ctx, x -> a:f(ctx, x, function('s:wrap_prev', [a:prev]))}
-endfunction
-
-function! s:wrap_prev(f, ctx, x, ...) abort
-  if a:0
-    return a:f(a:ctx, a:x, a:1)
-  else
-    return a:f(a:ctx, a:x, a:x)
-  endif
+  return l:result
 endfunction

--- a/autoload/wilder/render/component/arrows.vim
+++ b/autoload/wilder/render/component/arrows.vim
@@ -2,7 +2,7 @@ function! wilder#render#component#arrows#make_previous(args) abort
   let l:previous = get(a:args, 'previous', '< ')
 
   return {
-        \ 'value': {ctx, xs -> s:left(l:previous, ctx, xs)},
+        \ 'value': {ctx, result -> s:left(l:previous, ctx, result)},
         \ 'len': strdisplaywidth(l:previous),
         \ 'hl': get(a:args, 'hl', '')
         \ }
@@ -13,17 +13,17 @@ function! wilder#render#component#arrows#make_next(args) abort
   let l:next = get(a:args, 'next', ' >')
 
   return {
-        \ 'value': {ctx, xs -> s:right(l:previous, l:next, ctx, xs)},
+        \ 'value': {ctx, result -> s:right(l:previous, l:next, ctx, result)},
         \ 'len': strdisplaywidth(l:next),
         \ }
 endfunction
 
-function! s:left(previous, ctx, xs) abort
+function! s:left(previous, ctx, result) abort
   return a:ctx.page[0] > 0 ? a:previous : ''
 endfunction
 
-function! s:right(previous, next, ctx, xs) abort
-  let l:next_page_arrow = a:ctx.page[1] < len(a:xs) - 1 ?
+function! s:right(previous, next, ctx, result) abort
+  let l:next_page_arrow = a:ctx.page[1] < len(a:result.xs) - 1 ?
         \ a:next :
         \ repeat(' ', strdisplaywidth(a:next))
 

--- a/autoload/wilder/render/component/condition.vim
+++ b/autoload/wilder/render/component/condition.vim
@@ -7,7 +7,7 @@ function! wilder#render#component#condition#make(predicate, if_true, if_false) a
         \ }
 
   return {
-        \ 'value': {ctx, xs -> s:value(l:state, ctx, xs)},
+        \ 'value': {ctx, result -> s:value(l:state, ctx, result)},
         \ 'pre_hook': {ctx -> s:pre_hook(l:state, ctx)},
         \ 'post_hook': {ctx -> s:post_hook(l:state, ctx)},
         \ }
@@ -21,8 +21,8 @@ function! s:post_hook(state, ctx) abort
   call wilder#render#components_post_hook(a:state.if_true + a:state.if_false, a:ctx)
 endfunction
 
-function! s:value(state, ctx, xs) abort
-  let a:state.chosen = a:state.predicate(a:ctx, a:xs) ?
+function! s:value(state, ctx, result) abort
+  let a:state.chosen = a:state.predicate(a:ctx, a:result) ?
         \ a:state.if_true :
         \ a:state.if_false
 

--- a/autoload/wilder/render/component/index.vim
+++ b/autoload/wilder/render/component/index.vim
@@ -1,13 +1,13 @@
 function! wilder#render#component#index#make(args) abort
   return {
-        \ 'value': {ctx, xs -> s:value(a:args, ctx, xs)},
-        \ 'len': {ctx, xs -> len(len(xs)) * 2 + 1 + 2},
+        \ 'value': {ctx, result -> s:value(a:args, ctx, result)},
+        \ 'len': {ctx, result -> len(len(result.xs)) * 2 + 1 + 2},
         \ 'hl': get(a:args, 'hl', ''),
         \ }
 endfunction
 
-function! s:value(args, ctx, xs) abort
-  let l:num_xs = len(a:xs) == 0 ? '-' : len(a:xs)
+function! s:value(args, ctx, result) abort
+  let l:num_xs = len(a:result.xs) == 0 ? '-' : len(a:result.xs)
   let l:displaywidth = len(l:num_xs)
   let l:selected = a:ctx.selected == -1 ? '-' : a:ctx.selected + 1
 

--- a/autoload/wilder/render/component/spinner.vim
+++ b/autoload/wilder/render/component/spinner.vim
@@ -20,8 +20,8 @@ function! wilder#render#component#spinner#make(args) abort
         \ }
 
   return {
-        \ 'value': {ctx, xs -> s:spinner(l:state, ctx, xs)},
-        \ 'len': {ctx, xs -> strdisplaywidth(s:get_char(l:state, ctx, xs))},
+        \ 'value': {ctx, result -> s:spinner(l:state, ctx, result)},
+        \ 'len': {ctx, result -> strdisplaywidth(s:get_char(l:state, ctx, result))},
         \ 'hl': get(a:args, 'hl', ''),
         \ }
 endfunction
@@ -29,7 +29,7 @@ endfunction
 " set current_char in here so it is consistent with the actual rendered
 " char. Due to reltime(), the char might be changed since len is called
 " earlier
-function! s:get_char(state, ctx, xs) abort
+function! s:get_char(state, ctx, result) abort
   if a:ctx.done
     let a:state.was_done = 1
     let a:state.index = -1
@@ -59,7 +59,7 @@ function! s:get_char(state, ctx, xs) abort
   return a:state.frames[a:state.index]
 endfunction
 
-function! s:spinner(state, ctx, xs) abort
+function! s:spinner(state, ctx, result) abort
   if a:state.timer
     call timer_stop(a:state.timer)
   endif

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -147,10 +147,11 @@ A contrived example:
 This will return the 3 completions, the current cmdline and the strings 'foo'
 and 'bar'.
 
-The result of the pipeline should be a list. The elements of the list can
-either be a string or a |Dictionary| with a certain set of keys. See
-|wilder-pipeline-result| for more details on what the dictionary should
-contain.
+The result of the pipeline should be a list of strings or a dictionary. For
+the dictionary, the 'xs' value should be a list of strings. See
+|wilder-pipeline-result| for more details on other keys the dictionary
+contain, and see |wilder-pipeline-flow| for more details on how the result
+will be used.
 
 There are 3 special types of values, which when returned in the middle of the
 pipeline, will cause the pipeline to stop. These are `v:false` `v:true` and
@@ -231,23 +232,33 @@ This will call `MyCompletionFunction` after a 100 millisecond delay.
 Use this behaviour to create async pipeline components.
 
                                     *wilder-pipeline-result*
-The result of the pipeline should be a list. The elements of the list can
-either be a string or a Result |Dictionary| containing a specific set of keys.
+The result of the pipeline should be a list of strings or a dictionary. For
+the dictionary, the 'xs' value should be a list of strings.
 
-The Result dictionary allows you to change how the candidate is handled. For
+When the result is a list, it is implicitly converted into a dictionary with
+the list of keys under the 'xs' key.
+
+The result dictionary allows you to change how the candidate is handled. For
 example, you may wish to escape certain characters when drawing the candidate
 or only change certain parts of the cmdline when the candidate is selected.
 
-A Result dictionary has the following keys:
+The Result dictionary has the following keys:
 
-            `value`
+            `xs`                    *wilder-pipeline-result-xs*
             Mandatory~
-            The completion candidate.
+            The list of candidates as strings
 
-            `draw`
+            `draw`                  *wilder-pipeline-result-draw*
             Optional~
-            A function which takes a {ctx} and {x} and returns a string
-            representing how {x} will be drawn by the renderer.
+            A list of strings or functions which takes a {ctx} and {x} and
+            returns a string representing how {x} will be drawn by the
+            renderer.
+            For each element in the list, if the element is a string, it is
+            converted to a function using |function()|.
+            {ctx} and {x} are passed to the function and the result is a the
+            new value of {x}. {ctx} and the new value of {x} is then passed to
+            the next element. If there are no more elements, the final {x}
+            will be used.
 
             The keys of {ctx} are:
                 `selected`
@@ -258,54 +269,54 @@ A Result dictionary has the following keys:
 
             Default: None
 
-            `output`
+            `output`                *wilder-pipeline-result-output*
             Optional~
-            A function which takes a {ctx} and {x} and returns a string
-            representing how {x} will be output when selected as a completion
-            candidate.
+            A list of strings or functions which takes a {ctx} and {x} and
+            returns a string representing how {x} will be output when selected
+            as a completion candidate.
+            See the |wilder-pipeline-result-draw| option for how iterating
+            through the list works.
 
             {ctx} contains no keys.
 
             Default: None
 
-            `replace`
+            `replace`               *wilder-pipeline-result-replace*
             Optional~
-            A function which takes a {ctx} and {x} and returns the cmdline to
-            replace the current one. The cmdline is only replaced up to
-            where the cursor is.
+            A list of strings or functions which takes a {ctx} and {x} and
+            returns the cmdline to replace the current one
+            See |wilder-option-before_cursor| on which part of the cmdline will be
+            replaced.
+            See the |wilder-pipeline-result-draw| option for how iterating
+            through the list works.
 
             {ctx} contains no keys.
 
             Default: {_, x -> x}
 
-The flow of the pipeline goes like this:
+                                    *wilder-pipeline-flow*
 1. The pipeline starts with the current cmdline as the input
-2. The pipeline finishes with a list, containing strings and/or Results.
-3. For each completion candidate {x}, it is drawn by the renderer.
-   If {x} is a string, it is passed directly to the renderer.
-   If {x} is a dictionary, and has no `draw` key, its `value` entry is passed
-   to the renderer.
-   If {x} is a dictionary and has a `draw` entry, `draw` is called, with the
-   {x} argument being the `value` entry of the dictonary. The result of `draw`
-   is then passed to the renderer.
-4. When a candidate {x} is selected, its value can be modified before
+2. The pipeline finishes with a list of strings or a dictionary {result}.
+3. The list of strings is implicitly converted into a result dictionary with
+   the list of strings under the `xs` key.
+4. Each element of the `xs` list {x} is drawn by the renderer:
+   If {result} does not contain the key `draw`, its {x} entry is used.
+   Otherwise, |wilder-pipeline-result-draw| is applied. The result is then
+   passed to the renderer.
+5. When a candidate {x} is selected, its value can be modified before
    inserting it to the cmdline.
-   If {x} is a string, it is unchanged.
-   If {x} is a dictionary, and has no `output` key, its `value` entry will be
-   used.
-   If {x} is a dictionary and has a `output` entry, `output` is called, with
-   the {x} argument being the `value` entry of the dictonary. The result of
-   `output` will be used.
-5. Finally, the string or output from above will be inserted to the cmdline.
+   If {result} does not contain the key `output`, its {x} entry is used.
+   Otherwise, |wilder-pipeline-result-output| is applied. The result is then
+   used for insertion to the cmdline.
+6. Finally, the output from above will be inserted to the cmdline.
    See |wilder-option-before_cursor| on which part of the cmdline will be
    replaced.
-   If {x} is a dictionary and has a `replace` entry, `replace` is called, with
-   the {x} argument being the result from the step 4. The result of the
-   `replace` function will be inserted.
-   Otherwise, the result from step 4 will be inserted.
+   If {result} does not contain the key `output`, its {x} entry is used.
+   Otherwise, |wilder-pipeline-result-output| is applied. The result is then
+   used to replace the cmdline.
 
 The |wilder#result()| pipeline component is a helper component which allows
-easy modification of the result list.
+easy modification of the result dictionary.
 
 COMPONENTS                          *wilder-pipeline-components*
 
@@ -447,47 +458,38 @@ wilder#python_uniq()                *wilder#python_uniq()*
             Takes a list and returns a uniq-ed copy of the list.
 
 wilder#result([{dictionary}])       *wilder#result()*
-            Takes a dictionary and returns a component which will transform a
-            list into a list of Result dictonaries. See |wilder-pipeline-result|
-            for more information on how the Result dictionary is used.
+            Takes an {input} dictionary and returns a component which will
+            transform the input into a result dictionary and modifies its
+            keys.
+            See |wilder-pipeline-result| for more information on how the
+            keys of the dictionary is used.
 
-            For each element in the input to the component, if the element is
-            a string, it is converted into a dictionary with `value` entry as
-            the string.
+            For each {key} and {value} pair in {dictionary}:
+            If {value} is a list, and {input} does not contain {key},
+            {input}'s {key} is set to the list. Otherwise, the list is
+            appended to the end of the list at {input}'s {key}.
 
-            For the `value` {key} of the dictionary, the {value} should be a
-            function which takes a {ctx} and the current value of the Result
-            {x} and returns the new `value` for the Result.
+            If {value} is a dictionary, and {input} does not contain {key},
+            {input}'s {key} is set to the dictionary. Otherwise, the
+            dictionary at {input}'s {key} is extended with the dictionary
+            using |extend()|.
 
-            For each other {key}-{value} pair of the dictionary, {value}
-            should be a function which takes a {ctx}, {x} and {prev} and
-            returns the the new entry for {key} in the Result.
+            If {value} is a function, it should be a function which takes a
+            {ctx} and {old_value} and returns the new value to be used. If
+            input does not contain {key}, {old_value} will be |v:null|.
 
-            {ctx} contains the following keys if the {key} is `draw`:
-                `i`
-                The position of {x} in the list of candidates.
-
-                `selected`
-                True if {x} currently is selected.
-
-            Otherwise, the {ctx} contains no keys.
-
-            {prev} is a function which takes a {ctx}, {x} and {default} and
-            returns the new {value}. Passing the current {ctx} and {x} value
-            will return the result of evaluating the previous Result's {value}
-            with the same {key}. If the previous Result does not have an entry
-            for {key}, {default} is used.
-
-            {default} can be omitted as a shorthand for prev(ctx, x, x).
+            Otherwise, it contains the current value at {input}'s {key}.
+            If {value} is none of the above, the value at {input}'s {key} will
+            be replaced with {value}.
 
             For example:
 >
             [
             \ {ctx, x -> MyCompletionFunction(x)},
-            \ wilder#result({'draw': {ctx, x -> (ctx['i'] + 1) . '. ' . x}}),
-            \ wilder#result({'draw': {ctx, x, prev -> ctx['selected'] ?
+            \ wilder#result({'draw': [{ctx, x -> (ctx['i'] + 1) . '. ' . x}]}),
+            \ wilder#result({'draw': [{ctx, x, prev -> ctx['selected'] ?
             \                         '[' . prev(ctx, x) . ']' :
-            \                         prev(ctx, x)}}),
+            \                         prev(ctx, x)}]}),
             \ ]
 <
             This pipeline will first prepend the index of the candidate and
@@ -497,7 +499,8 @@ wilder#result([{dictionary}])       *wilder#result()*
                                     *wilder#result_output_escape()*
 wilder#result_output_escape({chars})
             Helper function which returns a |wilder#result()| which escapes
-            {chars} in the Result output.
+            {chars} in the `output` when selecting a candidate. See
+            |wilder-pipeline-flow| on how `output` is used.
 
 PIPELINES                           *wilder-pipelines*
 


### PR DESCRIPTION
Change the result of the pipeline from a list of dictionaries to a dictionary with a list of strings. Creating a list of dictionaries is expensive especially when there is a large number of candidates. This refactor also makes `draw` lazy so it does not have to be called for all candidates before being passed to the renderer.

**Breaking change as the list of dictionaries is not handled any more.**