### PR TITLE
Disable spelling check explicitly in float renderer

### DIFF
--- a/autoload/wilder/render/renderer/wildmenu_float.vim
+++ b/autoload/wilder/render/renderer/wildmenu_float.vim
@@ -102,6 +102,7 @@ function! s:new_win(buf) abort
   call nvim_win_set_option(l:win, 'list', v:false)
   call nvim_win_set_option(l:win, 'number', v:false)
   call nvim_win_set_option(l:win, 'relativenumber', v:false)
+  call nvim_win_set_option(l:win, 'spell', v:false)
 
   return l:win
 endfunction


### PR DESCRIPTION
spell mode is enabled by default in `float renderer` window. This commit disables it by default