### PR TITLE
File finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ call wilder#set_option('pipeline', [
       \     wilder#cmdline_pipeline(),
       \     wilder#python_search_pipeline(),
       \   ),
-      \ ]
+      \ ])
 ```
 
 When getting file completions, fuzzily search and match through all files under the current directory. Has to be placed above `wilder#cmdline_pipeline()`.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ call wilder#set_option('renderer', wilder#wildmenu_renderer({
       \ },
       \ 'apply_highlights':        " Experimental: applies highlighting to candidates
       \    wilder#query_common_subsequence_spans(),
-      \ 'separator': ' ',         " string used to separate candidates
+      \ 'separator': ' ',          " string used to separate candidates
       \ 'ellipsis': '...',         " string appended to truncated candidates which are too long
       \ })
 ```
@@ -151,9 +151,9 @@ Shows the index of the current candidate out of the total number of candidates -
 call wilder#set_option('renderer', wilder#wildmenu_renderer({
       \ 'spinner': [wilder#spinner({
       \   'frames': '-\|/',  " characters to show, can also be a list of strings
-      \   'done': ' ',  " string to show when there is no work to do or work has finished
-      \   'delay': 50,  " delay in ms before showing the spinner
-      \   'interval': 100,  " interval in ms for each frame to be shown
+      \   'done': ' ',       " string to show when there is no work to do or work has finished
+      \   'delay': 50,       " delay in ms before showing the spinner
+      \   'interval': 100,   " interval in ms for each frame to be shown
       \ )],
       \ })
 ```
@@ -166,7 +166,7 @@ The spinner indicates when `wilder` has async work which has not been completed 
 
 call wilder#set_option('renderer', wilder#wildmenu_renderer(
       \ wilder#airline_theme({  " use wilder#lightline_theme() for Lightline
-      \   'highlights': {},  " default highlights can be overridden, see :h wilder#wildmenu_renderer()
+      \   'highlights': {},     " default highlights can be overridden, see :h wilder#wildmenu_renderer()
       \   'apply_highlights': wilder#query_common_subsequence_spans(),
       \   'separator': ' · ',
       \ })))

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -44,12 +44,12 @@ endfunction
 
 " DEPRECATED: use wilder#resolve()
 function! wilder#on_finish(ctx, x)
-  return wilder#pipeline#resolve(a:ctx, a:x)
+  return call('wilder#resolve', [a:ctx, a:x])
 endfunction
 
 " DEPRECATED: use wilder#reject()
 function! wilder#on_error(ctx, x)
-  return wilder#pipeline#reject(a:ctx, a:x)
+  return call('wilder#reject', [a:ctx, a:x])
 endfunction
 
 function! wilder#wait(f, ...)
@@ -330,33 +330,8 @@ function! wilder#python_uniq() abort
   return {_, x -> {ctx -> _wilder_python_uniq(ctx, x)}}
 endfunction
 
-function! wilder#python_sort() abort
-  return {_, x -> {ctx -> _wilder_python_sort(ctx, x)}}
-endfunction
-
 function! wilder#_python_sleep(t) abort
   return {_, x -> {ctx -> _wilder_python_sleep(ctx, a:t, x)}}
-endfunction
-
-function! wilder#python_sorter_difflib() abort
-  return function('wilder#python_sort_difflib')
-endfunction
-
-function! wilder#python_sort_difflib(ctx, xs, query) abort
-  return {ctx -> _wilder_python_sort_difflib(ctx, {}, a:xs, a:query)}
-endfunction
-
-function! wilder#python_sorter_fuzzywuzzy() abort
-  return function('wilder#python_sort_fuzzywuzzy')
-endfunction
-
-function! wilder#python_sort_fuzzywuzzy(ctx, xs, query) abort
-  return {ctx -> _wilder_python_sort_fuzzywuzzy(ctx, {}, a:xs, a:query)}
-endfunction
-
-" DEPRECATED: use wilder#python_sort_fuzzywuzzy()
-function! wilder#python_fuzzywuzzy(ctx, xs, query) abort
-  return wilder#python_sort_fuzzywuzzy(a:ctx, a:xs, a:query)
 endfunction
 
 function! wilder#history(...) abort
@@ -369,9 +344,113 @@ function! wilder#history(...) abort
   endif
 endfunction
 
+function! wilder#python_sort() abort
+  return {_, x -> {ctx -> _wilder_python_sort(ctx, x)}}
+endfunction
+
+" sorters
+
+function! wilder#python_sorter_difflib(...) abort
+  let l:opts = {
+        \ 'quick': get(a:, 1, 1),
+        \ 'case_sensitive': get(a:, 2, 1),
+        \ }
+  return {ctx, xs, query -> wilder#python_sort_difflib(ctx, l:opts, xs, query)}
+endfunction
+
+function! wilder#python_sort_difflib(ctx, opts, xs, query) abort
+  return {ctx -> _wilder_python_sort_difflib(ctx, a:opts, a:xs, a:query)}
+endfunction
+
+function! wilder#python_sorter_fuzzywuzzy(...) abort
+  let l:opts = {
+        \ 'partial': get(a:, 1, 1),
+        \ }
+  return {ctx, xs, query -> wilder#python_sort_fuzzywuzzy(ctx, l:opts, xs, query)}
+endfunction
+
+" DEPRECATED: use wilder#python_sort_fuzzywuzzy()
+function! wilder#python_fuzzywuzzy(ctx, xs, query) abort
+  return call('wilder#python_sort_fuzzywuzzy', [a:ctx, {}, a:xs, a:query])
+endfunction
+
+function! wilder#python_sort_fuzzywuzzy(ctx, opts, xs, query) abort
+  return {ctx -> _wilder_python_sort_fuzzywuzzy(ctx, a:opts, a:xs, a:query)}
+endfunction
+
+" filters
+
+function! s:variadic(f, t)
+  return funcref('s:variadic_call', [a:f, a:t])
+endfunction
+
+function! s:variadic_call(f, t, ...)
+  return call(a:f, a:t(a:000))
+endfunction
+
+" DEPRECATED: use wilder#filter_fuzzy()
+function! wilder#fuzzy_filter() abort
+  return call('wilder#filter_fuzzy', [])
+endfunction
+
+function! wilder#filter_fuzzy() abort
+  return s:variadic('wilder#filt_fuzzy', {args -> [args[0], {}] + args[1:]})
+endfunction
+
+function! wilder#filt_fuzzy(ctx, opts, candidates, query, ...) abort
+  return wilder#cmdline#filter_fuzzy(a:ctx, a:candidates, a:query, get(a:, 1, 0))
+endfunction
+
+" DEPRECATED: use wilder#python_filter_fuzzy()
+function! wilder#python_fuzzy_filter(...) abort
+  return call('wilder#python_filter_fuzzy', a:000)
+endfunction
+
+function! wilder#python_filter_fuzzy(...) abort
+  let l:opts = {
+        \ 'engine': get(a:, 1, 're'),
+        \ }
+  return s:variadic('wilder#python_filt_fuzzy', {args -> [args[0], l:opts] + args[1:]})
+endfunction
+
+function! wilder#python_filt_fuzzy(ctx, opts, candidates, query, ...) abort
+  return wilder#cmdline#python_filter_fuzzy(a:ctx, a:opts, a:candidates, a:query, get(a:, 1, 0))
+endfunction
+
+function! wilder#python_filter_fruzzy(...) abort
+  let l:opts = {
+        \ 'limit': get(a:, 1, 1000),
+        \ 'fruzzy_path': get(a:, 2, wilder#fruzzy_path()),
+        \ }
+  return s:variadic('wilder#python_filt_fruzzy', {args -> [args[0], l:opts] + args[1:]})
+endfunction
+
+function! wilder#python_filt_fruzzy(ctx, opts, candidates, query, ...) abort
+  return wilder#cmdline#python_filter_fruzzy(a:ctx, a:opts, a:candidates, a:query, get(a:, 1, 0))
+endfunction
+
+function! wilder#python_filter_cpsm(...) abort
+  let l:opts = {
+        \ 'cpsm_path': get(a:, 1, wilder#cpsm_path()),
+        \ }
+  return s:variadic('wilder#python_filt_cpsm', {args -> [args[0], l:opts] + args[1:]})
+endfunction
+
+function! wilder#python_filt_cpsm(ctx, opts, candidates, query) abort
+  return wilder#cmdline#python_filter_cpsm(a:ctx, a:opts, a:candidates, a:query)
+endfunction
+
 " pipelines
 
 function! wilder#search_pipeline(...) abort
+  let l:opts = get(a:, 1, {})
+
+  return has('nvim') ?
+        \ wilder#python_search_pipeline(l:opts) :
+        \ wilder#vim_search_pipeline(l:opts)
+endfunction
+
+function! s:search_pipeline(...) abort
   let l:opts = a:0 > 0 ? a:1 : {}
 
   let l:pipeline = [wilder#check({_, x -> !empty(x)})]
@@ -399,7 +478,7 @@ function! wilder#search_pipeline(...) abort
 endfunction
 
 function! wilder#vim_search_pipeline(...) abort
-  return wilder#search_pipeline(get(a:, 1, {}))
+  return s:search_pipeline(get(a:, 1, {}))
 endfunction
 
 function! s:extract_keys(obj, ...)
@@ -435,15 +514,15 @@ function! wilder#python_search_pipeline(...) abort
   call add(l:subpipeline, wilder#python_search(
         \ s:extract_keys(l:opts, 'max_candidates', 'engine')))
 
-  let l:Sort = get(l:opts, 'sort', 0)
-  if l:Sort isnot 0
-    if l:Sort is 'python_sort_fuzzywuzzy'
-      let l:Sort = function('wilder#python_sort_fuzzywuzzy')
-    elseif l:Sort is 'python_sort_difflib'
-      let l:Sort = function('wilder#python_sort_difflib')
+  let l:Sorter = get(l:opts, 'sorter', get(l:opts, 'sort', 0))
+  if l:Sorter isnot 0
+    if l:Sorter is 'python_sort_fuzzywuzzy'
+      let l:Sorter = wilder#python_sorter_fuzzywuzzy()
+    elseif l:Sorter is 'python_sort_difflib'
+      let l:Sorter = wilder#python_sorter_difflib()
     endif
 
-    call add(l:subpipeline, {ctx, xs -> l:Sort(ctx, xs, ctx.input)})
+    call add(l:subpipeline, {ctx, xs -> l:Sorter(ctx, xs, ctx.input)})
   endif
 
   call add(l:subpipeline, wilder#result_output_escape('^$*~[]/\'))
@@ -452,7 +531,7 @@ function! wilder#python_search_pipeline(...) abort
         \ wilder#result({'data': {'pcre2.pattern': x}}),
         \ ]}))
 
-  return wilder#search_pipeline({
+  return s:search_pipeline({
         \ 'debounce': get(l:opts, 'debounce', 0),
         \ 'pipeline': l:pipeline,
         \ 'skip_cmdtype_check': get(l:opts, 'skip_cmdtype_check', 0),
@@ -469,45 +548,6 @@ endfunction
 
 function! wilder#python_file_finder_pipeline(...) abort
   return wilder#cmdline#python_file_finder_pipeline(get(a:, 1, {}))
-endfunction
-
-" DEPRECATED: use wilder#filter_fuzzy()
-function! wilder#fuzzy_filter() abort
-  return function('wilder#cmdline#filter_fuzzy')
-endfunction
-
-function! wilder#filter_fuzzy() abort
-  return function('wilder#cmdline#filter_fuzzy')
-endfunction
-
-" DEPRECATED: use wilder#python_filter_fuzzy()
-function! wilder#python_fuzzy_filter(...) abort
-  let l:opts = {
-        \ 'engine': get(a:, 1, 're'),
-        \ }
-  return function('wilder#cmdline#python_filter_fuzzy', [l:opts])
-endfunction
-
-function! wilder#python_filter_fuzzy(...) abort
-  let l:opts = {
-        \ 'engine': get(a:, 1, 're'),
-        \ }
-  return function('wilder#cmdline#python_filter_fuzzy', [l:opts])
-endfunction
-
-function! wilder#python_filter_fruzzy(...) abort
-  let l:opts = {
-        \ 'limit': get(a:, 1, 1000),
-        \ 'fruzzy_path': get(a:, 2, wilder#fruzzy_path()),
-        \ }
-  return function('wilder#cmdline#python_filter_fruzzy', [l:opts])
-endfunction
-
-function! wilder#python_filter_cpsm(...) abort
-  let l:opts = {
-        \ 'cpsm_path': get(a:, 1, wilder#cpsm_path()),
-        \ }
-  return function('wilder#cmdline#python_filter_cpsm', [l:opts])
 endfunction
 
 " render components
@@ -533,11 +573,7 @@ endfunction
 
 " DEPRECATED: use wilder#separator()
 function! wilder#separator(str, from, to, ...) abort
-  if a:0
-    return wilder#render#component#separator#make(a:str, a:from, a:to, a:1)
-  else
-    return wilder#render#component#separator#make(a:str, a:from, a:to)
-  endif
+  return call('wilder#separator', [a:str, a:from, a:to] + a:000)
 endfunction
 
 function! wilder#powerline_separator(str, from, to, ...) abort
@@ -598,76 +634,49 @@ function! wilder#lightline_theme(...)
   return wilder#render#renderer#wildmenu_theme#lightline_theme(l:args)
 endfunction
 
-let s:fruzzy_path = 0
-function! wilder#fruzzy_path(...) abort
-  let l:use_cached = get(a:, 1, 1)
-
-  if l:use_cached && s:fruzzy_path isnot 0
-    return s:fruzzy_path
-  endif
-
-  let s:fruzzy_path = s:get_fruzzy_path()
-  return s:fruzzy_path
-endfunction
-
-function! s:get_fruzzy_path() abort
+function! s:find_function_script_file(f)
   try
     " ensure function is autoloaded
-    silent call fruzzy#version()
-  catch
-    return ''
-  endtry
-
-  let l:output = execute('verbose function fruzzy#version')
-  let l:lines = split(l:output, '\n')
-  if len(l:lines) < 2
-    return ''
-  endif
-
-  let l:matches = matchlist(l:lines[1], 'Last set from \(.*\) line \d\+')
-  if len(l:matches) < 2
-    return ''
-  endif
-
-  let l:path = l:matches[1]
-  return simplify(l:path . '/../../rplugin/python3')
-endfunction
-
-let s:cpsm_path = 0
-function! wilder#cpsm_path() abort
-  let l:use_cached = get(a:, 1, 1)
-
-  if l:use_cached && s:cpsm_path isnot 0
-    return s:cpsm_path
-  endif
-
-  let s:cpsm_path = s:get_cpsm_path()
-  return s:cpsm_path
-endfunction
-
-function! s:get_cpsm_path() abort
-  try
-    " ensure function is autoloaded
-    silent call cpsm#CtrlPMatch()
+    silent call eval(a:f . '()')
   catch /E119/
     " success
   catch
     return ''
   endtry
 
-  let l:output = execute('verbose function cpsm#CtrlPMatch')
+  let l:output = execute('verbose function ' . a:f)
   let l:lines = split(l:output, '\n')
   if len(l:lines) < 2
     return ''
   endif
 
-  let l:matches = matchlist(l:lines[1], 'Last set from \(.*\) line \d\+')
+  let l:matches = matchlist(l:lines[1], 'Last set from \(\S\+\)')
   if len(l:matches) < 2
     return ''
   endif
 
-  let l:path = l:matches[1]
-  return simplify(l:path . '/..')
+  return l:matches[1]
+endfunction
+
+let s:module_path_cache = {}
+
+function! s:get_module_path(f, modify_path, use_cached)
+  if !a:use_cached || !has_key(s:module_path_cache, a:f)
+    let l:file = s:find_function_script_file(a:f)
+    let s:module_path_cache[a:f] = empty(l:file) ?
+          \ '' :
+          \ simplify(l:file . a:modify_path)
+  endif
+
+  return s:module_path_cache[a:f]
+endfunction
+
+function! wilder#fruzzy_path(...) abort
+  return s:get_module_path('fruzzy#version', '/../../rplugin/python3', get(a:, 1, 1))
+endfunction
+
+function! wilder#cpsm_path(...) abort
+  return s:get_module_path('cpsm#CtrlPMatch', '/..', get(a:, 1, 1))
 endfunction
 
 let s:project_root_cache = {}
@@ -686,7 +695,7 @@ function! wilder#clear_project_root_cache() abort
   let s:project_root_cache = {}
 endfunction
 
-function! s:project_root(root_markers) abort
+function! s:project_root(root_markers, ...) abort
   if a:0
     let l:path = a:1
   else

--- a/autoload/wilder/cmdline/main.vim
+++ b/autoload/wilder/cmdline/main.vim
@@ -672,7 +672,7 @@ function! wilder#cmdline#main#do(ctx) abort
   endif
 
   let a:ctx.pos = l:arg_start
-endfunc
+endfunction
 
 function! wilder#cmdline#main#has_file_args(cmd) abort
   let l:flags = get(s:command_flags, a:cmd, 0)
@@ -682,7 +682,7 @@ endfunction
 function! wilder#cmdline#main#is_whitespace(char) abort
   let l:nr = char2nr(a:char)
   return a:char ==# ' ' || l:nr >= 9 && l:nr <= 13
-endfunc
+endfunction
 
 function! wilder#cmdline#main#skip_whitespace(ctx) abort
   if empty(a:ctx.cmdline[a:ctx.pos])

--- a/autoload/wilder/main.vim
+++ b/autoload/wilder/main.vim
@@ -4,6 +4,7 @@ let s:enabled = 1
 let s:init = 0
 let s:active = 0
 let s:hidden = 0
+let s:session_id = 0
 let s:run_id = 0
 let s:result_run_id = -1
 let s:draw_done = 0
@@ -111,6 +112,8 @@ function! s:start() abort
           \ ),
           \ ]
   endif
+
+  let s:session_id += 1
 
   call s:pre_hook()
 
@@ -254,6 +257,7 @@ function! s:run_pipeline(input, ...) abort
   let l:ctx = {
         \ 'input': a:input,
         \ 'run_id': s:run_id,
+        \ 'session_id': s:session_id,
         \ }
 
   if a:0 > 0

--- a/autoload/wilder/options.vim
+++ b/autoload/wilder/options.vim
@@ -9,8 +9,12 @@ call extend(s:opts, {
       \ 'num_workers': 2,
       \ })
 
-function! wilder#options#get() abort
-  return s:opts
+function! wilder#options#get(...) abort
+  if !a:0
+    return s:opts
+  endif
+
+  return s:opts[a:1]
 endfunction
 
 function! wilder#options#set(x, ...) abort

--- a/autoload/wilder/pipeline/component/debounce.vim
+++ b/autoload/wilder/pipeline/component/debounce.vim
@@ -1,0 +1,18 @@
+function! wilder#pipeline#component#debounce#make(t) abort
+  let l:state = {
+        \ 'timer': 0,
+        \ 'interval': a:t,
+        \ }
+
+  return {ctx, x -> s:debounce(l:state, ctx, x)}
+endfunction
+
+function! s:debounce(state, _, x) abort
+  return {ctx -> s:start(a:state, ctx, a:x)}
+endfunction
+
+function! s:start(state, ctx, x) abort
+  call timer_stop(a:state['timer'])
+  let a:state['timer'] = timer_start(
+        \ a:state.interval, {-> wilder#resolve(a:ctx, a:x)})
+endfunction

--- a/autoload/wilder/render/component/spinner.vim
+++ b/autoload/wilder/render/component/spinner.vim
@@ -4,7 +4,7 @@ function! wilder#render#component#spinner#make(args) abort
     let l:frames = split(l:frames, '\zs')
   endif
 
-  let l:Done = get(a:args, 'done', ' ')
+  let l:Done = get(a:args, 'done', '·')
   let l:delay = get(a:args, 'delay', 50)
   let l:interval = get(a:args, 'interval', 100)
 

--- a/autoload/wilder/render/renderer/wildmenu_theme.vim
+++ b/autoload/wilder/render/renderer/wildmenu_theme.vim
@@ -88,14 +88,11 @@ function! s:theme(opts, namespace, hls) abort
         \     wilder#condition(
         \       {ctx, x -> has_key(ctx, 'error')},
         \       '!',
-        \       wilder#spinner({
-        \         'frames': '-\|/',
-        \         'done': '·',
-        \       }),
+        \       wilder#spinner()
         \     ), ' '],
         \   'hl': l:highlights['mode']
         \   },
-        \   l:use_powerline_symbols ? 
+        \   l:use_powerline_symbols ?
         \     wilder#powerline_separator(
         \       l:powerline_symbols[0], l:highlights['mode'],
         \       l:highlights['default'], 'left') : '',
@@ -103,7 +100,7 @@ function! s:theme(opts, namespace, hls) abort
         \ ],
         \ 'right': [
         \    ' ',
-        \   l:use_powerline_symbols ? 
+        \   l:use_powerline_symbols ?
         \     wilder#powerline_separator(
         \       l:powerline_symbols[1], l:highlights['index'],
         \       l:highlights['default'], 'right') : '',

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -397,7 +397,7 @@ wilder#branch({list_of_pipelines})  *wilder#branch()*
                   \       wilder#check({ctx, x -> empty(x)}),
                   \       wilder#history(),
                   \     ],
-                  \     wilder#vim_search_pipeline(),
+                  \     wilder#search_pipeline(),
                   \   ),
                   \   ]
 <
@@ -582,7 +582,16 @@ wilder#result_output_escape({chars})
             {chars} in the `output` when selecting a candidate. See
             |wilder-pipeline-flow| on how `output` is used.
 
+
 PIPELINES                           *wilder-pipelines*
+
+wilder#search_pipeline([{options}]) *wilder#search_pipeline()*
+                                    Pipeline~
+            Returns a |wilder#python_search_pipeline()| for Neovim and a
+            |wilder#vim_search_pipeline()| for Vim.
+
+            If provided, the {options} argument is passed to the respective
+            function.
 
                                     *wilder#vim_search_pipeline()*
 wilder#vim_search_pipeline([{options}])
@@ -634,7 +643,7 @@ wilder#python_search_pipeline([{options}])
 
             Default: Empty
 
-            `sort`
+            `sorter`
             Optional~
             A function is used to sort the candidates. The function should
             take a {ctx}, {candidates} and {query} and return the sorted
@@ -664,6 +673,9 @@ wilder#python_search_pipeline([{options}])
 
             Default: 0
 
+            `sort`
+            Deprecated: Use `sorter`.
+
                                     *wilder#cmdline_pipeline()*
 wilder#cmdline_pipeline([{options}])
                                     Neovim only~
@@ -683,11 +695,18 @@ wilder#cmdline_pipeline([{options}])
 
             {options} is a dictionary with keys:
             `fuzzy`
-            When true, use fuzzy matching for the results.
+            0, 1, or 2 representing the fuzzy matching mode. If 0, fuzzy
+            matching is disabled. If 1, fuzzy matching is done and candidates
+            have to start with the first character of the query. If 2, the
+            candidates do not have to start with the first character.
+
             Note: Fuzzy matching does not work in some cases, e.g. when
             getting |help| completions, when completing filenames with
             |wildcards| or user-defined command completions
             |:command-completion|.
+
+            Note: When set to 2, `shellcmd` candidates will still start with
+            the first character of the query due to performance reasons.
 
             Default: 0
 
@@ -700,10 +719,11 @@ wilder#cmdline_pipeline([{options}])
 
             `fuzzy_filter`
             The function to use when matching candidates in fuzzy completion.
-            Takes a {ctx}, {candidates}, {query} and optional {transform}
-            function and returns the list of filtered candidates.
-            The {transform} function takes a {x} and returns the transformed
-            {x}.
+            Takes a {ctx}, {candidates}, {query} and optional {transform} and
+            returns the list of filtered candidates. 
+            If {transform} is provided, it can either be a function or 0. If
+            0, it should be ignored. Otherwise, it is a function that takes a
+            {candidate} and returns the transformed {candidate}.
             The filtering should be done on the transformed candidates, but
             the returned list should contain the untransformed candidates.
 
@@ -728,7 +748,7 @@ wilder#cmdline_pipeline([{options}])
 
             Default: has('nvim') && !has('nvim-0.3.7')
 
-            `sort`
+            `sorter`
             Optional~
             A function is used to sort the candidates. The function should
             take a {ctx}, {candidates} and {query} and return the sorted
@@ -755,8 +775,11 @@ wilder#cmdline_pipeline([{options}])
 
             Default: 1
 
-wilder#python_file_finder_pipeline([{options}])
+            `sort`
+            Deprecated: Use `sorter`.
+
                                     *wilder#python_file_finder_pipeline()*
+wilder#python_file_finder_pipeline([{options}])
                                     Neovim only~
                                     Async~
                                     Pipeline~
@@ -767,7 +790,7 @@ wilder#python_file_finder_pipeline([{options}])
 
             If the path for the argument is not relative to the current
             directory, or cannot be resolved as a descendant of the current
-            path, the pipeline will return |v:false|.
+            path, or starts with './', the pipeline will return |v:false|.
 
             Note |wilder#python_file_finder_pipeline()| should be placed in
             front of |wilder#cmdline_pipeline()| when using |wilder#branch()|.
@@ -778,17 +801,17 @@ wilder#python_file_finder_pipeline([{options}])
             A list of strings representing the command to be used to retrieve
             the list of files.
 
-            Examples:
-            `ripgrep`: ['rg', '--files']
-            `fd`: ['fd', '-tf']
+            To use `ripgrep`, set to this option to ['rg', '--files'].
+            To use `fd`, set to this option to ['fd', '-tf'].
 
             Default: ['find', '.', '-type', 'f', '-printf', '%P\n']
 
             `timeout`
             Optional~
-            A timeout in milliseconds. If the process to gather the list of
-            files does not end before the timeout, the process is killed. Any
-            subsequent call to the pipeline will result in |v:false|.
+            A timeout in milliseconds. If the process used to gather the list
+            of files does not finish before the timeout, the process is
+            killed.  Any subsequent call to the pipeline will result in
+            |v:false|.
 
             Default: 5000
 
@@ -805,9 +828,10 @@ wilder#python_file_finder_pipeline([{options}])
             gather the files from. If it is a string, it will be converted to
             a function which returns the string.
 
-            The function should take an argument {ctx} and return the
-            directory. The directory path should be absolute and not relative.
-            Returning an empty string will search in the current directory.
+            The function should take {ctx} and {res} as arguments and return
+            the directory to search in. The directory path should be an
+            absolute path and not a relative one.  Returning an empty string
+            will search in the current directory.
 
             Default: |wilder#project_root()|
 
@@ -878,6 +902,7 @@ wilder#python_file_finder_pipeline([{options}])
             `sort_difflib`
             Sorts the list with |wilder#python_sort_difflib()|.
 
+            Options:
                 `case_sensitive`
                 Optional~
                 0 or 1 representing whether the sorting is case sensitive.
@@ -1137,31 +1162,15 @@ wilder#wildmenu_renderer([{options}])
 
             `hl`
             Deprecated: Use `highlights`.
-            Optional~
-            The default highlight group.
-
-            Default: 'StatusLine'
 
             `selected_hl`
             Deprecated: Use `highlights`.
-            Optional~
-            The highlight group for the selected candidate.
-
-            Default: 'WildMenu'
 
             `error_hl`
             Deprecated: Use `highlights`.
-            Optional~
-            The highlight group of error messages.
-
-            Default: 'StatusLine'
 
             `separator_hl`
             Deprecated: Use `highlights`.
-            Optional~
-            The highlight group of the separator between candidates.
-
-            Default: same value as the `hl` option
 
                                     *wilder#airline_theme()*
                                     *wilder#lightline_theme()*
@@ -1700,38 +1709,40 @@ wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
                                     Deprecated~
             Deprecated: Use |wilder#filter_fuzzy()|.
 
-                                    *wilder#python_filter_fuzzy()*
-wilder#python_filter_fuzzy([{engine}])
+                                    *wilder#python_filt_fuzzy()*
+wilder#python_filt_fuzzy({ctx}, {opts}, {candidates}, {query}, {transformed})
                                     Neovim only~
                                     Async~
-            Returns a fuzzy filter to use for `fuzzy_filter` in
-            |wilder#cmdline_pipeline()|.
-            The filter matches a {candidate} if it contains all the characters
-            in {query} and in the same order.
-            The filter uses Python 3. {engine} is the regex engine to use. Has
-            to be compatible with Python 3's `re` module. Defaults to 're' if
-            not set.
+            Takes a list of candidates and fuzzily filters and sorts the
+            candidates using Python.
+
+            A {candidate} is matched if it contains all the characters in
+            {query} and in the same order.
 
             e.g. `foobar` will match `fbr`
                  `foobar` will not match `frb`
+
+            Options contains no keys.
+
+wilder#python_filter_fuzzy()        *wilder#python_filter_fuzzy()*
+                                    Neovim only~
+                                    Async~
+            Returns a fuzzy filter that filters and sorts the candidates using
+            |wilder#python_filt_fuzzy()|. Can be used as the `fuzzy_filter`
+            option in |wilder#cmdline_pipeline()|.
+
 
 wilder#python_fuzzy_filter()        *wilder#python_fuzzy_filter()*
                                     Deprecated~
             Deprecated: Use |wilder#python_filter_fuzzy()|.
 
-                                    *wilder#python_filter_fruzzy()*
-wilder#python_filter_fruzzy([{limit}, [{fruzzy_path}]])
+                                    *wilder#python_filt_fruzzy()*
+wilder#python_filt_fruzzy({ctx}, {opts}, {candidates}, {query}, {transformed})
                                     Neovim only~
                                     Async~
                                     fruzzy plugin required~
-            Returns a fuzzy filter to use for `fuzzy_filter` in
-            |wilder#cmdline_pipeline()|.
-            The filter filters and sorts the candidates using `fruzzy`.
-            {limit} is the maximum number of candidates to return. Defaults to
-            1000.
-
-            {fruzzy_path} can be provided to set the path for `fruzzy.py`. It
-            is inferred by Neovim otherwise.
+            Takes a list of candidates and fuzzily filters and sorts the
+            candidates using `fruzzy`.
 
             The `fruzzy` plugin can be found at
             https://github.com/raghur/fruzzy.
@@ -1739,44 +1750,114 @@ wilder#python_filter_fruzzy([{limit}, [{fruzzy_path}]])
             Note that the native module is not supported due to the use of
             multiple threads.
 
-                                    *wilder#python_filter_cpsm()*
-wilder#python_filter_cpsm([{cpsm_path}])
+            {opts} can contain the following keys:
+            `limmit`
+            Optional~
+            The maximum number of candidates to return.
+
+            Default: 1000
+
+            `fruzzy_path`
+            Optional~
+            The path to `fruzzy.py`. If left empty, Python will not attempt
+            to add the path.
+
+            Default: None
+
+                                    *wilder#python_filter_fruzzy()*
+wilder#python_filter_fruzzy([{limit}, [{fruzzy_path}]])
                                     Neovim only~
-                                    Async~
-                                    cpsm plugin required~
+                                    fruzzy plugin required~
             Returns a fuzzy filter that filters and sorts the candidates using
-            `cpsm`. The `cpsm` Vim plugin is required and can be found at
-            https://github.com/nixprime/cpsm.
+            |wilder#python_filt_cpsm()|. Can be used as the `fuzzy_filter`
+            option in |wilder#cmdline_pipeline()|.
 
             Note this filter does not support the {transformed} argument and
             cannot be used as a `fuzzy_filter` for
             |wilder#cmdline_pipeline()|.
 
+            The {limit} and {fruzzy_path} arguments are passed to
+            |wilder#python_filt_cpsm()| as options.
+
+            {fruzzy_path} can be provided to set the path for `fruzzy.py`.
+            It is inferred by Neovim otherwise.
+
+
+                                    *wilder#python_filt_cpsm()*
+wilder#python_filt_cpsm({ctx}, {opts}, {candidates}, {query})
+                                    Neovim only~
+                                    Async~
+                                    cpsm plugin required~
+            Takes a list of candidates and fuzzily filters and sorts the
+            candidates using `cpsm`. The `cpsm` Vim plugin is required and can
+            be found at https://github.com/nixprime/cpsm.
+
+            {opts} can contain the following keys:
+            `cpsm_path`
+            Optional~
+            The path to `cpsm_py.so`. If left empty, Python will not attempt
+            to add the path.
+
+            Default: None
+
+                                    *wilder#python_filter_cpsm()*
+wilder#python_filter_cpsm([{cpsm_path}])
+                                    Neovim only~
+                                    cpsm plugin required~
+            Returns a fuzzy filter that filters and sorts the candidates using
+            |wilder#python_filt_cpsm()|.
+
+            Note this filter does not support the {transformed} argument and
+            cannot be used as a `fuzzy_filter` for
+            |wilder#cmdline_pipeline()|.
+
+            The {cpsm_path} argument is passed to |wilder#python_filt_cpsm()|
+            as an option.
+
             {cpsm_path} can be provided to set the path for `cpsm_py.so`. It
             is inferred by Neovim otherwise.
 
                                     *wilder#python_sort_difflib()*
-wilder#python_sort_difflib({ctx}, {candidates}, {query})
+wilder#python_sort_difflib({ctx}, {opts}, {candidates}, {query})
                                     Neovim only~
                                     Async~
             Takes a list of candidates and a query and returns a
             |wilder-pipeline-thunk| which sorts the candidates using
             `difflib.SequenceMatcher`.
 
+            {opts} can contain the following keys:
+            `quick`
+            Optional~
+            Boolean indicating whether to use the `quick_ratio` scorer for the
+            `SequenceMatcher`. Otherwise `ratio` is used.
+
+            Default: 1
+
+            `case_sensitive`
+            Optional~
+            Boolean indicating whether the sort should be case sensitive.
+
+            Default: 1
+
             Example:
 >
-             wilder#result({'value': {ctx, xs ->
-               wilder#python_sort_difflib(ctx, xs, ctx.input)}}})
+            wilder#result({'value': {ctx, xs ->
+                  \ wilder#python_sort_difflib(ctx, {}, xs, ctx.input)}}})
 <
 
 
-wilder#python_sorter_difflib()      *wilder#python_sorter_difflib()*
+                                    *wilder#python_sorter_difflib()*
+wilder#python_sorter_difflib([{quick}, [{case_sensitive}]])
                                     Neovim only~
-            Returns a |Funcref| to |wilder#python_sort_difflib()| which can be
-            used as the `sorter` option in |wilder#cmdline_pipeline()|.
+            Returns a sorter which uses |wilder#python_sort_difflib()| to sort
+            the candidates. Can be used as the `sorter` option in
+            |wilder#cmdline_pipeline()|.
+
+            The {quick} and {case_sensitive} arguments are passed to
+            |wilder#python_sort_difflib()| as options.
 
                                     *wilder#python_sort_fuzzywuzzy()*
-wilder#python_sort_fuzzywuzzy({ctx}, {candidates}, {query})
+wilder#python_sort_fuzzywuzzy({ctx}, {opts}, {candidates}, {query})
                                     Neovim only~
                                     Async~
                                     Python 3 fuzzywuzzy module required~
@@ -1786,17 +1867,30 @@ wilder#python_sort_fuzzywuzzy({ctx}, {candidates}, {query})
 
             `fuzzywuzzy` can be installed using `pip install fuzzywuzzy`.
 
+            {opts} can contain the following keys:
+            `partial`
+            Optional~
+            Boolean indicating whether to use the `partial_ratio` scorer.
+            Otherwise `ratio` is used.
+
+            Default: 1
+
             Example:
 >
-             wilder#result({'value': {ctx, xs ->
-               wilder#python_sort_fuzzywuzzy(ctx, xs, ctx.input)}}})
+            wilder#result({'value': {ctx, xs ->
+                  \ wilder#python_sort_fuzzywuzzy(ctx, {}, xs, ctx.input)}}})
 <
 
-wilder#python_sorter_fuzzywuzzy()   *wilder#python_sorter_fuzzywuzzy()*
+                                    *wilder#python_sorter_fuzzywuzzy()*
+wilder#python_sorter_fuzzywuzzy([{partial}])
                                     Neovim only~
                                     Python 3 fuzzywuzzy module required~
-            Returns a |Funcref| to |wilder#python_sort_fuzzywuzzy()| which can
-            be used as the `sorter` option in |wilder#cmdline_pipeline()|.
+            Returns a sorter which uses |wilder#python_sort_fuzzywuzzy()| to
+            sort the candidates. Can be used as the `sorter` option in
+            |wilder#cmdline_pipeline()|.
+
+            The {partial} argument is passed to
+            |wilder#python_sort_fuzzywuzzy()| as an option.
 
                                     *wilder#python_fuzzywuzzy()*
 wilder#python_fuzzywuzzy({ctx}, {candidates}, {query})
@@ -1901,7 +1995,6 @@ Minimal Configuration~
 Pipelines (Neovim only)~
 >
     " add minimal configuration
-
     call wilder#set_option('pipeline', [
           \   wilder#branch(
           \     [

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -362,6 +362,18 @@ wilder#check({f}, ...)              *wilder#check()*
             |v:false|.
             Returns {x} otherwise.
 
+wilder#debounce({t})                *wilder#debounce()*
+                                    Pipeline component~
+            Takes a time interval {t} in milliseconds.
+            When this component is reached, the pipeline is interrupted. The
+            pipeline only continues when the same component has not been
+            reached for {t} milliseconds.
+            The pipeline then continues with the latest value passed to the
+            component.
+
+            Note that using debounce in |wilder#branch()| will stall all
+            branches since the branches are run sequentially.
+
 wilder#branch({list_of_pipelines})  *wilder#branch()*
                                     Pipeline component~
             Takes a list of pipelines. The pipelines should be a list of
@@ -632,8 +644,8 @@ wilder#python_search_pipeline([{options}])
             If no function is provided, no sorting will be done on the
             candidates.
 
-            For Neovim, |wilder#python_sort_difflib()| and
-            |wilder#python_sort_fuzzywuzzy()| can be used here.
+            For Neovim, |wilder#python_sorter_difflib()| and
+            |wilder#python_sorter_fuzzywuzzy()| can be used here.
 
             Default: Empty
 
@@ -642,6 +654,13 @@ wilder#python_search_pipeline([{options}])
             If true, skips checking that |getcmdtype()| is '/' or '?'.  This
             is useful when using the pipeline as the `pipeline` option for
             |wilder#substitute_pipeline()|.
+
+            Default: 0
+
+            `debounce`
+            Optional~
+            An interval in milliseconds. If greater than 0, debounces the
+            pipeline using |wilder#debounce()|.
 
             Default: 0
 
@@ -699,8 +718,8 @@ wilder#cmdline_pipeline([{options}])
             Can return a |wilder-pipeline-thunk|.  Only used if `fuzzy` is
             true.
 
-            Default: |wilder#python_fuzzy_filter()| if `use_python` is true
-                     |wilder#fuzzy_filter()| otherwise
+            Default: |wilder#python_filter_fuzzy()| if `use_python` is true
+                     |wilder#filter_fuzzy()| otherwise
 
             `hide_in_substitute`
             When true, hides wilder when in a |:substitute| command.
@@ -735,6 +754,141 @@ wilder#cmdline_pipeline([{options}])
             PCRE2.
 
             Default: 1
+
+wilder#python_file_finder_pipeline([{options}])
+                                    *wilder#python_file_finder_pipeline()*
+                                    Neovim only~
+                                    Async~
+                                    Pipeline~
+                                    Experimental~
+            Returns a pipeline which matches files fuzzily. This pipeline is
+            used when the cmdline is expanding `file` completions, which for
+            example occurs when in the |:edit| command.
+
+            If the path for the argument is not relative to the current
+            directory, or cannot be resolved as a descendant of the current
+            path, the pipeline will return |v:false|.
+
+            Note |wilder#python_file_finder_pipeline()| should be placed in
+            front of |wilder#cmdline_pipeline()| when using |wilder#branch()|.
+
+            {options} is a dictionary with keys:
+            `command`
+            Optional~
+            A list of strings representing the command to be used to retrieve
+            the list of files.
+
+            Examples:
+            `ripgrep`: ['rg', '--files']
+            `fd`: ['fd', '-tf']
+
+            Default: ['find', '.', '-type', 'f', '-printf', '%P\n']
+
+            `timeout`
+            Optional~
+            A timeout in milliseconds. If the process to gather the list of
+            files does not end before the timeout, the process is killed. Any
+            subsequent call to the pipeline will result in |v:false|.
+
+            Default: 5000
+
+            `debounce`
+            Optional~
+            An interval in milliseconds. If greater than 0, debounces the
+            pipeline using |wilder#debounce()|.
+
+            Default: 0
+
+            `dir`
+            Optional~
+            A function or a string representing the path to the directory to
+            gather the files from. If it is a string, it will be converted to
+            a function which returns the string.
+
+            The function should take an argument {ctx} and return the
+            directory. The directory path should be absolute and not relative.
+            Returning an empty string will search in the current directory.
+
+            Default: |wilder#project_root()|
+
+            `filters`
+            Optional~
+            A list of filters to be used on the list of files. The list of
+            files is passed through the filters sequentially and the final
+            result is returned to the pipeline.
+
+            Each element can either be a string representing the filter or an
+            object in the form {'name': {string}, ['opts': {dictonary}]},
+            where the optional `opts` key represents the options are passed to
+            the filter. If a string is used, it is implicitly converted into a
+            dictionary with no options.
+
+            Can be set to an empty list to return the entire list of files.
+
+            For performance, using `cpsm` with ['filter_cpsm'] is recommended.
+
+            The available filters are:
+            `filter_fuzzy`
+            Filters the list with |wilder#python_filter_fuzzy()|.
+
+            Options:
+                `engine`
+                Optional~
+                The regex engine to use.
+
+                Default: 're'
+
+                `case_sensitive`
+                Optional~
+                0, 1 or 2 representing how to handle case sensitivity. 0
+                indicates the filter is not case sensitive and 1 otherwise.
+                Setting to 2 makes the filter use "smartcase" where 'a'
+                matches with 'a|A' and 'A' matches with 'A' ony.
+
+                Default: 2
+
+            `filter_fruzzy`
+            Filters and sorts the list with |wilder#python_filter_fruzzy()|.
+            The `fruzzy.vim` Vim plugin is needed.
+
+            Options:
+                `limit`
+                Optional~
+                Maximum number of candidates to return.
+
+                Default: 1000
+
+                `fruzzy_path`
+                Optional~
+                The parent directory of the `fruzzy.py` file.
+
+                Default: Inferred by Neovim.
+
+            `filter_cpsm`
+            Filters and sorts the list with |wilder#python_filter_cpsm()|.
+            The `cpsm` Vim plugin is required.
+
+            Options:
+                `cpsm_path`
+                Optional~
+                The parent directory of the `cpsm_py.so` file.
+
+                Default: Inferred by Neovim.
+
+            `sort_difflib`
+            Sorts the list with |wilder#python_sort_difflib()|.
+
+                `case_sensitive`
+                Optional~
+                0 or 1 representing whether the sorting is case sensitive.
+
+                Default: 1
+
+            `sort_fuzzywuzzy`
+            Sorts the list with |wilder#python_sort_fuzzywuzzy()|. The Python3
+            `fuzzywuzzy` module is needed.
+
+            Default: ['fuzzy', 'difflib']
 
                                     *wilder#substitute_pipeline()*
 wilder#substitute_pipeline([{options}])
@@ -939,7 +1093,6 @@ wilder#wildmenu_renderer([{options}])
 
             `apply_highlights`
             Optional~
-            Experimental~
             A list of functions used to apply the `accent` and
             `selected_accent` highlights to a candidate. For convenience, also
             accepts a single function, which will be converted to a singleton
@@ -1266,7 +1419,7 @@ wilder#spinner([{options}])         *wilder#spinner()*
             is no pipeline running, or when the `delay` timeout has not been
             reached.
 
-            Default: ' '
+            Default: '·'
 
             `delay`
             Optional~
@@ -1534,7 +1687,7 @@ wilder#hl_with_attr({name}, {hl_group}, {attr} [, ..., {attrN}])
 
             Returns the name of the new highlight group.
 
-wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
+wilder#filter_fuzzy()               *wilder#filter_fuzzy()*
             Returns a fuzzy filter to use for `fuzzy_filter` in
             |wilder#cmdline_pipeline()|.
             The filter matches a {candidate} if it contains all the characters
@@ -1543,8 +1696,12 @@ wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
             e.g. `foobar` will match `fbr`
                  `foobar` will not match `frb`
 
-                                    *wilder#python_fuzzy_filter()*
-wilder#python_fuzzy_filter([{engine}])
+wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
+                                    Deprecated~
+            Deprecated: Use |wilder#filter_fuzzy()|.
+
+                                    *wilder#python_filter_fuzzy()*
+wilder#python_filter_fuzzy([{engine}])
                                     Neovim only~
                                     Async~
             Returns a fuzzy filter to use for `fuzzy_filter` in
@@ -1555,9 +1712,48 @@ wilder#python_fuzzy_filter([{engine}])
             to be compatible with Python 3's `re` module. Defaults to 're' if
             not set.
 
-
             e.g. `foobar` will match `fbr`
                  `foobar` will not match `frb`
+
+wilder#python_fuzzy_filter()        *wilder#python_fuzzy_filter()*
+                                    Deprecated~
+            Deprecated: Use |wilder#python_filter_fuzzy()|.
+
+                                    *wilder#python_filter_fruzzy()*
+wilder#python_filter_fruzzy([{limit}, [{fruzzy_path}]])
+                                    Neovim only~
+                                    Async~
+                                    fruzzy plugin required~
+            Returns a fuzzy filter to use for `fuzzy_filter` in
+            |wilder#cmdline_pipeline()|.
+            The filter filters and sorts the candidates using `fruzzy`.
+            {limit} is the maximum number of candidates to return. Defaults to
+            1000.
+
+            {fruzzy_path} can be provided to set the path for `fruzzy.py`. It
+            is inferred by Neovim otherwise.
+
+            The `fruzzy` plugin can be found at
+            https://github.com/raghur/fruzzy.
+
+            Note that the native module is not supported due to the use of
+            multiple threads.
+
+                                    *wilder#python_filter_cpsm()*
+wilder#python_filter_cpsm([{cpsm_path}])
+                                    Neovim only~
+                                    Async~
+                                    cpsm plugin required~
+            Returns a fuzzy filter that filters and sorts the candidates using
+            `cpsm`. The `cpsm` Vim plugin is required and can be found at
+            https://github.com/nixprime/cpsm.
+
+            Note this filter does not support the {transformed} argument and
+            cannot be used as a `fuzzy_filter` for
+            |wilder#cmdline_pipeline()|.
+
+            {cpsm_path} can be provided to set the path for `cpsm_py.so`. It
+            is inferred by Neovim otherwise.
 
                                     *wilder#python_sort_difflib()*
 wilder#python_sort_difflib({ctx}, {candidates}, {query})
@@ -1573,6 +1769,12 @@ wilder#python_sort_difflib({ctx}, {candidates}, {query})
                wilder#python_sort_difflib(ctx, xs, ctx.input)}}})
 <
 
+
+wilder#python_sorter_difflib()      *wilder#python_sorter_difflib()*
+                                    Neovim only~
+            Returns a |Funcref| to |wilder#python_sort_difflib()| which can be
+            used as the `sorter` option in |wilder#cmdline_pipeline()|.
+
                                     *wilder#python_sort_fuzzywuzzy()*
 wilder#python_sort_fuzzywuzzy({ctx}, {candidates}, {query})
                                     Neovim only~
@@ -1582,11 +1784,19 @@ wilder#python_sort_fuzzywuzzy({ctx}, {candidates}, {query})
             |wilder-pipeline-thunk| which sorts the candidates using
             `fuzzywuzzy`.
 
+            `fuzzywuzzy` can be installed using `pip install fuzzywuzzy`.
+
             Example:
 >
              wilder#result({'value': {ctx, xs ->
                wilder#python_sort_fuzzywuzzy(ctx, xs, ctx.input)}}})
 <
+
+wilder#python_sorter_fuzzywuzzy()   *wilder#python_sorter_fuzzywuzzy()*
+                                    Neovim only~
+                                    Python 3 fuzzywuzzy module required~
+            Returns a |Funcref| to |wilder#python_sort_fuzzywuzzy()| which can
+            be used as the `sorter` option in |wilder#cmdline_pipeline()|.
 
                                     *wilder#python_fuzzywuzzy()*
 wilder#python_fuzzywuzzy({ctx}, {candidates}, {query})
@@ -1661,6 +1871,15 @@ wilder#pcre2_capture_spans([{opts}])
             Note: This function is slow and should be avoided by users who are
             concerned about performance. Using 'lua' is slightly faster, but
             will still have performance issues.
+
+                                    *wilder#project_root()*
+wilder#project_root([{root_markers}])
+            Takes an optional list of paths and returns a function which tries
+            to locate the root directory of the project from the current
+            directory.
+
+            {root_markers} is a list of file or directory names and defaults
+            to ['.hg', '.git'].
 
 ==============================================================================
 7. Configurations                   *wilder-configurations*

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -504,8 +504,9 @@ wilder#python_search([{options}])   *wilder#python_search()*
             `engine`
             Regex engine to use. Has to be compatible with Python 3's `re`
             module.
-            For faster completions, `re2` is recommended, but needs to be
-            installed.
+            For faster speed, the `re2` module is recommended. `re2` for
+            Python3 can be installed by using `pip install pyre2` or built
+            from https://github.com/andreasvc/pyre2.
 
             Default: 're'
 
@@ -1646,7 +1647,7 @@ wilder#pcre2_capture_spans([{opts}])
 
             The Lua pcre2 package is required this option is set to 'lua'.
             The pcre2 package source can be found at
-            `https://github.com/mah0x211/lua-pcre2` and can be installed with
+            https://github.com/mah0x211/lua-pcre2 and can be installed with
             `luarocks install pcre2`.
 
             Default: 'python'

--- a/rplugin/python3/wilder/__init__.py
+++ b/rplugin/python3/wilder/__init__.py
@@ -4,17 +4,21 @@ import difflib
 import fnmatch
 import functools
 import glob
+import heapq
 import importlib
 from importlib.util import find_spec
+import io
 import itertools
 import multiprocessing
 import os
 from pathlib import Path
 import pwd
 import shutil
+import subprocess
+import sys
+from tempfile import TemporaryFile
 import threading
 import time
-
 
 if find_spec('pynvim'):
     import pynvim as neovim
@@ -28,10 +32,14 @@ class Wilder(object):
         self.has_init = False
         self.queue = multiprocessing.Queue()
         self.events = []
-        self.lock = threading.Lock()
+        self.events_lock = threading.Lock()
         self.executor = None
         self.cached_buffer = {'bufnr': -1, 'undotree_seq_cur': -1, 'buffer': []}
         self.run_id = -1
+        self.find_files_lock = threading.Lock()
+        self.find_files_session_id = -1
+        self.path_files_dict = dict()
+        self.added_sys_path = set()
 
     def handle(self, ctx, x, command='resolve'):
         self.nvim.call('wilder#' + command, ctx, x)
@@ -43,34 +51,32 @@ class Wilder(object):
         event = threading.Event()
         ctx = args[0]
 
-        with self.lock:
-            if ctx['run_id'] < self.run_id:
+        old_events = []
+        with self.events_lock:
+            run_id = ctx['run_id']
+            if run_id < self.run_id:
                 return
-            self.run_id = ctx['run_id']
 
-            while len(self.events) > 0:
-                e = self.events.pop(0)
-                e.set()
+            if run_id > self.run_id:
+                self.run_id = run_id
+                old_events = self.events
+                self.events = []
 
             self.events.append(event)
 
-        self.executor.submit(functools.partial( fn, *([event] + args), ))
+        for ev in old_events:
+            ev.set()
+
+        return self.executor.submit(functools.partial( fn, *([event] + args), ))
 
     def consumer(self):
         while True:
             args = self.queue.get()
-
             ctx = args[0]
             res = args[1]
-            while not self.queue.empty():
-                new_args = self.queue.get_nowait()
-                new_ctx = new_args[0]
 
-                if (new_ctx['run_id'] > ctx['run_id'] or
-                        (new_ctx['run_id'] == ctx['run_id'] and new_ctx['step'] > ctx['step'])):
-                    args = new_args
-                    ctx = args[0]
-                    res = args[1]
+            if ctx['run_id'] < self.run_id:
+                continue
 
             if len(args) > 2:
                 command = args[2]
@@ -79,7 +85,7 @@ class Wilder(object):
                 self.nvim.async_call(self.handle, ctx, res)
 
     @neovim.function('_wilder_init', sync=True)
-    def init(self, args):
+    def _init(self, args):
         if self.has_init:
             return
 
@@ -91,8 +97,137 @@ class Wilder(object):
         t = threading.Thread(target=self.consumer, daemon=True)
         t.start()
 
-    @neovim.function('_wilder_python_sleep', sync=False, allow_nested=True)
-    def sleep(self, args):
+    def add_sys_path(self, path):
+        path = os.path.expanduser(path)
+
+        if not path in self.added_sys_path:
+            self.added_sys_path.add(path)
+            sys.path.insert(0, path)
+
+    @neovim.function('_wilder_python_file_finder', sync=False)
+    def _file_finder(self, args):
+        self.run_in_background(self.file_finder_handler, args)
+
+    def file_finder_handler(self, event, ctx, opts, cwd, path, query):
+        try:
+            if not path:
+                path = cwd
+
+            path = Path(os.path.expanduser(path)).resolve()
+            path_str = str(path)
+
+            command = opts['command'] if 'command' in opts else ['find', '.', '-type', 'f', '-printf', '%P\\n']
+            timeout_ms = opts['timeout'] if 'timeout' in opts else 5000
+            filters = opts['filters'] if 'filters' in opts else \
+                    [{'name': 'filter_fuzzy', 'opts': {}}, {'name': 'sort_difflib', 'opts': {}}]
+
+            result = None
+            with self.find_files_lock:
+                if ctx['session_id'] > self.find_files_session_id:
+                    self.find_files_session_id = ctx['session_id']
+                    self.path_files_dict = dict()
+
+                if path_str in self.path_files_dict:
+                    result = self.path_files_dict[path_str]
+                else:
+                    kill_event = threading.Event()
+                    done_event = threading.Event()
+                    result = {'kill': kill_event, 'done': done_event}
+                    self.path_files_dict[path_str] = result
+                    self.executor.submit(functools.partial( self.find_files_subprocess, *([command, path, timeout_ms, result]), ))
+
+            while True:
+                if result['done'].is_set():
+                    break
+                if event.wait(timeout=0.01):
+                    return
+
+            if 'timeout' in result:
+                self.queue.put((ctx, False,))
+                return
+
+            if 'error' in result:
+                self.queue.put((ctx, 'find_files: ' + result['error'], 'reject',))
+                return
+
+            candidates = result['files']
+
+            if not candidates:
+                return self.queue.put((ctx, [],))
+
+            if query:
+                for filter in filters:
+                    filter_name = filter['name']
+                    filter_opts = filter['opts']
+
+                    if filter_name == 'filter_cpsm':
+                        filter_opts['ispath'] = True
+                        candidates = self.filter_cpsm(event, filter_opts, query, candidates)
+
+                    elif filter_name == 'filter_fruzzy':
+                        candidates = self.filter_fruzzy(event, filter_opts, query, candidates, False)
+
+                    elif filter_name == 'filter_fuzzy':
+                        case_sensitive = filter_opts['case_sensitive'] if 'case_sensitive' in filter_opts else 2
+                        pattern = self.make_fuzzy_pattern(query, case_sensitive)
+                        candidates = self.filter_fuzzy(event, filter_opts, pattern, candidates, False)
+
+                    elif filter_name == 'sort_difflib':
+                        candidates = self.sort_difflib(event, filter_opts, candidates, query)
+
+                    elif filter_name == 'sort_fuzzywuzzy':
+                        candidates = self.sort_fuzzywuzzy(event, filter_opts, candidates, query)
+
+                    else:
+                        raise Exception('Unsupported filter: ' + filter_name)
+
+                    if candidates is None or event.is_set():
+                        return
+                    candidates = list(candidates)
+
+            if event.is_set():
+                return
+
+            relpath = os.path.relpath(path, cwd)
+            if relpath != '.':
+                candidates = [os.path.join(relpath, c) for c in candidates]
+
+            self.queue.put((ctx, candidates,))
+        except Exception as e:
+            self.queue.put((ctx, 'python_file_finder: ' + str(e), 'reject'))
+
+    def find_files_subprocess(self, command, path, timeout_ms, result):
+        try:
+            with TemporaryFile() as output:
+                with subprocess.Popen(
+                        command, bufsize=0, stdin=subprocess.DEVNULL,
+                        stdout=output, stderr=subprocess.DEVNULL, cwd=path) as p:
+                    start_time = time.time()
+                    while p.poll() is None:
+                        if time.time() - start_time >= timeout_ms / 1000:
+                            result['timeout'] = 'timeout after %dms' % (timeout_ms)
+                            p.kill()
+                            break
+                        if result['kill'].wait(timeout=0.01):
+                            p.kill()
+                            break
+
+                    if p.returncode is not 0:
+                        # rg sets error code 2 for partial matches, which we are fine with
+                        if command[0] is not 'rg' and p.returncode is not 2:
+                            result['error'] = 'non-zero return code %d ' % (p.returncode)
+                            return
+
+                    output.seek(0)
+                    buff = output.read()
+                    result['files'] = [line.decode('utf-8') for line in buff.splitlines()]
+        except Exception as e:
+            result['error'] = str(e)
+        finally:
+            result['done'].set()
+
+    @neovim.function('_wilder_python_sleep', sync=False)
+    def _sleep(self, args):
         self.run_in_background(self.sleep_handler, args)
 
     def sleep_handler(self, event, ctx, t, x):
@@ -103,11 +238,7 @@ class Wilder(object):
         self.queue.put((ctx, x,))
 
     @neovim.function('_wilder_python_search', sync=False)
-    def search(self, args):
-        if args[2] == "":
-            self.handle(args[1], [])
-            return
-
+    def _search(self, args):
         bufnr = self.nvim.current.buffer.number
         undotree_seq_cur = self.nvim.eval('undotree().seq_cur')
         if (bufnr != self.cached_buffer['bufnr'] or
@@ -120,43 +251,42 @@ class Wilder(object):
 
         self.run_in_background(self.search_handler, args + [self.cached_buffer['buffer']])
 
-    def search_handler(self, event, ctx, opts, x, buf):
-        if event.is_set():
-            return
-
+    def search_handler(self, event, ctx, *args):
         try:
-            module_name = opts['engine'] if 'engine' in opts else 're'
-            max_candidates = opts['max_candidates'] if 'max_candidates' in opts else 300
+            candidates = list(self.search(event, *args))
 
-            seen = set()
-            candidates = []
+            if event.is_set():
+                return
 
-            re = importlib.import_module(module_name)
-            # re2 does not use re.UNICODE by default
-            pattern = re.compile(x, re.UNICODE)
-
-            for line in buf:
-                if event.is_set():
-                    return
-                for match in pattern.finditer(line):
-                    if event.is_set():
-                        return
-                    candidate = match.group()
-                    if not candidate in seen:
-                        seen.add(candidate)
-                        candidates.append(candidate)
-                        if max_candidates > 0 and len(candidates) >= max_candidates:
-                            self.queue.put((ctx, candidates,))
-                            return
             self.queue.put((ctx, candidates,))
         except Exception as e:
             self.queue.put((ctx, 'python_search: ' + str(e), 'reject',))
-        finally:
-            with self.lock:
-                self.events.remove(event)
 
-    @neovim.function('_wilder_python_uniq', sync=False, allow_nested=True)
-    def uniq(self, args):
+    def search(self, event, opts, x, buf):
+        module_name = opts['engine'] if 'engine' in opts else 're'
+        max_candidates = opts['max_candidates'] if 'max_candidates' in opts else 300
+
+        re = importlib.import_module(module_name)
+        # re2 does not use re.UNICODE by default
+        pattern = re.compile(x, re.UNICODE)
+
+        seen = set()
+        checker = EventChecker(event)
+        for line in buf:
+            for match in pattern.finditer(line):
+                if checker.check():
+                    return
+
+                candidate = match.group()
+                if not candidate in seen:
+                    seen.add(candidate)
+                    yield candidate
+
+                    if max_candidates > 0 and len(seen) >= max_candidates:
+                        return
+
+    @neovim.function('_wilder_python_uniq', sync=False)
+    def _uniq(self, args):
         self.run_in_background(self.uniq_handler, args)
 
     def uniq_handler(self, event, ctx, candidates):
@@ -171,8 +301,8 @@ class Wilder(object):
         except Exception as e:
             self.queue.put((ctx, 'python_uniq: ' + str(e), 'reject',))
 
-    @neovim.function('_wilder_python_sort', sync=False, allow_nested=True)
-    def sort(self, args):
+    @neovim.function('_wilder_python_sort', sync=False)
+    def _sort(self, args):
         self.run_in_background(self.sort_handler, args)
 
     def sort_handler(self, event, ctx, candidates):
@@ -187,7 +317,7 @@ class Wilder(object):
             self.queue.put((ctx, 'python_sort: ' + str(e), 'reject',))
 
     @neovim.function('_wilder_python_get_file_completion', sync=False)
-    def get_file_completion(self, args):
+    def _get_file_completion(self, args):
         if args[2] == 'file_in_path':
             path_opt = self.nvim.eval('&path')
             directories = path_opt.split(',')
@@ -299,8 +429,8 @@ class Wilder(object):
             return os.path.basename(f[:-1])
         return os.path.basename(f)
 
-    @neovim.function('_wilder_python_get_users', sync=False, allow_nested=True)
-    def get_users(self, args):
+    @neovim.function('_wilder_python_get_users', sync=False)
+    def _get_users(self, args):
         self.run_in_background(self.get_users_handler, args)
 
     def get_users_handler(self, event, ctx, expand_arg, expand_type):
@@ -319,65 +449,240 @@ class Wilder(object):
         except Exception as e:
             self.queue.put((ctx, 'python_get_users: ' + str(e), 'reject',))
 
-    @neovim.function('_wilder_python_filter', sync=False, allow_nested=True)
-    def filter(self, args):
-        self.run_in_background(self.filter_handler, args)
+    @neovim.function('_wilder_python_filter_fuzzy', sync=False)
+    def _filter_fuzzy(self, args):
+        self.run_in_background(self.filter_fuzzy_handler, args)
 
-    def filter_handler(self, event, ctx, pattern, candidates, transformed, engine):
-        if event.is_set():
-            return
-
+    def filter_fuzzy_handler(self, event, ctx, *args):
         try:
-            if transformed == 0:
-                transformed = candidates
+            candidates = list(self.filter_fuzzy(event, *args))
 
-            re = importlib.import_module(engine)
-            # re2 does not use re.UNICODE by default
-            pattern = re.compile(pattern, re.UNICODE)
-            res = [x for i, x in enumerate(candidates) if pattern.search(transformed[i])]
-            self.queue.put((ctx, list(res),))
+            if event.is_set():
+                return
+
+            self.queue.put((ctx, candidates,))
         except Exception as e:
-            self.queue.put((ctx, 'python_filter: ' + str(e), 'reject',))
+            self.queue.put((ctx, 'python_filter_fuzzy: ' + str(e), 'reject',))
 
-    @neovim.function('_wilder_python_sort_difflib', sync=False, allow_nested=True)
-    def sort_difflib(self, args):
+    # case_sensitive: 0 - case insensitive
+    #                 1 - case sensitive
+    #                 2 - smartcase - x matches x|X, X matches X
+    def make_fuzzy_pattern(self, query, case_sensitive=2):
+        chars = list(query)
+        pattern = '(?i)' if not case_sensitive else ''
+
+        first = True
+        for char in chars:
+            if not first:
+                pattern += '.*?'
+            first = False
+
+            if char == '\\':
+                pattern += '\\\\'
+            elif (char == '.' or
+                    char == '^' or
+                    char == '$' or
+                    char == '*' or
+                    char == '+' or
+                    char == '?' or
+                    char == '|' or
+                    char == '(' or
+                    char == ')' or
+                    char == '{' or
+                    char == '}' or
+                    char == '[' or
+                    char == ']'):
+                pattern += '\\' + char + ''
+            else:
+                if case_sensitive == 2:
+                    if char.isupper():
+                        pattern += char
+                    else:
+                        pattern += '(' + char + '|' + char.upper() + ')'
+                else:
+                    pattern += char
+
+        return pattern
+
+    def filter_fuzzy(self, event, opts, pattern, candidates, transformed):
+        if not transformed:
+            transformed = candidates
+
+        engine = opts['engine'] if 'engine' in opts else 're'
+        re = importlib.import_module(engine)
+        # re2 does not use re.UNICODE by default
+        pattern = re.compile(pattern, re.UNICODE)
+
+        checker = EventChecker(event)
+        for index, candidate in enumerate(candidates):
+            if checker.check():
+                return
+
+            if pattern.search(transformed[index]):
+                yield candidate
+
+    @neovim.function('_wilder_python_filter_fruzzy', sync=False)
+    def _filter_fruzzy(self, args):
+        self.run_in_background(self.filter_fruzzy_handler, args)
+
+    def filter_fruzzy_handler(self, event, ctx, *args):
+        try:
+            candidates = list(self.filter_fruzzy(event, *args))
+
+            if event.is_set():
+                return
+
+            self.queue.put((ctx, candidates,))
+        except Exception as e:
+            self.queue.put((ctx, 'python_filter_fruzzy: ' + str(e), 'reject',))
+
+    def filter_fruzzy(self, *args):
+        opts = args[1]
+
+        if 'fruzzy_path' in opts:
+            self.add_sys_path(opts['fruzzy_path'])
+
+        use_native = opts['use_native'] if 'use_native' in opts else False
+
+        if should_use_native or use_native:
+            return self.filter_fruzzy_native(*args)
+
+        return self.filter_fruzzy_py(*args)
+
+    def filter_fruzzy_native(self, event, opts, query, candidates, transformed):
+        fruzzy_mod = importlib.import_module('fruzzy_mod')
+        limit = opts['limit'] if 'limit' in opts else 1000
+
+        if transformed:
+            zipped = zip(candidates, transformed)
+            indexes = fruzzy_mod.scoreMatchesStr(query, zipped, '', limit, key=lambda x: x[1])
+        else:
+            indexes = fruzzy_mod.scoreMatchesStr(query, candidates, '', limit)
+
+        sorted_matches = []
+        for index, score in indexes:
+            sorted_matches.append(candidates[index])
+
+        return sorted_matches
+
+    def filter_fruzzy_py(self, event, opts, query, candidates, transformed):
+        fruzzy = importlib.import_module('fruzzy')
+        limit = opts['limit'] if 'limit' in opts else 1000
+
+        if transformed:
+            zipped = zip(candidates, transformed)
+            matches = fruzzy.fuzzyMatches(query, zipped, '', limit, key=lambda x: x[1])
+        else:
+            matches = fruzzy.fuzzyMatches(query, candidates, '', limit)
+
+        checker = EventChecker(event)
+        arr = []
+        for match in matches:
+            if checker.check():
+                return
+            arr.append(match)
+
+        sorted_matches = heapq.nlargest(limit, arr, key=lambda i: i[5])
+
+        if transformed:
+            return [match[0][0] for match in sorted_matches]
+
+        return [match[0] for match in sorted_matches]
+
+    @neovim.function('_wilder_python_filter_cpsm', sync=False)
+    def _filter_cpsm(self, args):
+        self.run_in_background(self.filter_cpsm_handler, args)
+
+    def filter_cpsm_handler(self, event, ctx, *args):
+        try:
+            candidates = list(self.filter_cpsm(event, *args))
+
+            if event.is_set():
+                return
+
+            self.queue.put((ctx, candidates,))
+        except Exception as e:
+            self.queue.put((ctx, 'python_filter_cpsm: ' + str(e), 'reject',))
+
+    # cpsm does not support `transformed`
+    def filter_cpsm(self, event, opts, query, candidates):
+        if 'cpsm_path' in opts:
+            self.add_sys_path(opts['cpsm_path'])
+
+        ispath = opts['ispath'] if 'ispath' in opts else False
+
+        cpsm = importlib.import_module('cpsm_py')
+        return cpsm.ctrlp_match(candidates, query, ispath=ispath)[0]
+
+    @neovim.function('_wilder_python_sort_difflib', sync=False)
+    def _sort_difflib(self, args):
         self.run_in_background(self.sort_difflib_handler, args)
 
-    def sort_difflib_handler(self, event, ctx, candidates, query, quick=True):
+    def sort_difflib_handler(self, event, ctx, *args):
         if event.is_set():
             return
 
         try:
-            if quick:
-                res = sorted(candidates, key=lambda x: -difflib.SequenceMatcher(
-                    None, x, query).quick_ratio())
-            else:
-                res = sorted(candidates, key=lambda x: -difflib.SequenceMatcher(
-                    None, x, query).ratio())
-            self.queue.put((ctx, list(res),))
+            candidates = list(self.sort_difflib(event, *args))
+
+            if event.is_set():
+                return
+
+            self.queue.put((ctx, candidates,))
         except Exception as e:
             self.queue.put((ctx, 'python_sort_difflib: ' + str(e), 'reject',))
 
-    @neovim.function('_wilder_python_sort_fuzzywuzzy', sync=False, allow_nested=True)
-    def sort_fuzzywuzzy(self, args):
+    def sort_difflib(self, event, opts, candidates, query):
+        quick = opts['quick'] if 'quick' in opts else True
+        case_sensitive = opts['case_sensitive'] if 'case_sensitive' in opts else True
+
+        xs = [None] * len(candidates)
+        checker = EventChecker(event)
+        for index, candidate in enumerate(candidates):
+            if checker.check():
+                return
+
+            if case_sensitive:
+                matcher = difflib.SequenceMatcher(None, candidate, query)
+            else:
+                matcher = difflib.SequenceMatcher(None, candidate.lower(), query.lower())
+            score = -matcher.quick_ratio() if quick else -matcher.ratio()
+            xs[index] = (candidate, score,)
+
+        return [x[0] for x in sorted(xs, key=lambda x: x[1])]
+
+    @neovim.function('_wilder_python_sort_fuzzywuzzy', sync=False)
+    def _sort_fuzzywuzzy(self, args):
         self.run_in_background(self.sort_fuzzywuzzy_handler, args)
 
-    def sort_fuzzywuzzy_handler(self, event, ctx, candidates, query, partial=True):
-        if event.is_set():
-            return
-
+    def sort_fuzzywuzzy_handler(self, event, ctx, *args):
         try:
-            fuzzy = importlib.import_module('fuzzywuzzy.fuzz')
-            if partial:
-                res = sorted(candidates, key=lambda x: -fuzzy.partial_ratio(x, query))
-            else:
-                res = sorted(candidates, key=lambda x: -fuzzy.ratio(x, query))
-            self.queue.put((ctx, list(res),))
+            candidates = list(self.sort_fuzzywuzzy(event, *args))
+
+            if event.is_set():
+                return
+
+            self.queue.put((ctx, candidates,))
         except Exception as e:
             self.queue.put((ctx, 'python_sort_fuzzywuzzy: ' + str(e), 'reject',))
 
+    def sort_fuzzywuzzy(self, event, opts, candidates, query):
+        fuzzy = importlib.import_module('fuzzywuzzy.fuzz')
+        partial = opts['partial'] if 'partial' in opts else True
+        ratio = fuzzy.partial_ratio if partial else fuzzy.ratio
+
+        xs = [None] * len(candidates)
+        checker = EventChecker(event)
+        for index, candidate in enumerate(candidates):
+            if checker.check():
+                return []
+
+            xs[index] = (candidate, -ratio(candidate, query),)
+
+        return [x[0] for x in sorted(xs, key=lambda x: x[1])]
+
     @neovim.function('_wilder_python_common_subsequence_spans', sync=True)
-    def common_subsequence_spans(self, args):
+    def _common_subsequence_spans(self, args):
         string = args[0]
         query = args[1]
         case_sensitive = args[2]
@@ -415,7 +720,7 @@ class Wilder(object):
         return spans
 
     @neovim.function('_wilder_python_pcre2_capture_spans', sync=True)
-    def capture_spans(self, args):
+    def _capture_spans(self, args):
         pattern = args[0]
         string = args[1]
         module_name = args[2]
@@ -438,3 +743,17 @@ class Wilder(object):
             captures.append([byte_start, byte_len])
 
         return captures
+
+class EventChecker:
+    def __init__(self, event, interval_s=0.1):
+        self.event = event
+        self.interval_s = interval_s
+        self.last_check = time.time()
+
+    def check(self):
+        now = time.time()
+        if now - self.last_check < self.interval_s:
+            return False
+
+        self.last_check = now
+        return self.event.is_set()


### PR DESCRIPTION
### New features
- Added `wilder#python_file_finder_pipeline()`
- Added `wilder#python_filter_fruzzy()`
- Added `wilder#python_filter_cpsm()`

### Fixes
- Fixed cmdline fuzzy matching incorrectly when query contains Unicode characters
- Fixed python `file_in_path` expansion including duplicates
- Fixed python `shell` and `file_in_path` expansion not handling certain arguments (e.g. wildcards) correctly

### Breaking changes
- `wilder#spinner()` default `done` option changed from `' '` to `'·'`
- `wilder#python_sort_difflib()` and `wilder#python_sort_fuzzywuzzy()` now take an additional `options` dictionary as the second argument. It is recommended to use `wilder#python_sorter_*()` instead of using the `sort` methods directly.