### PR TITLE
fix: help tag mistake

### DIFF
--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -2332,9 +2332,9 @@ wilder#python_uniq()                *wilder#python_uniq()*
                                     Deprecated~
             Deprecated: Use |wilder#python_filter_uniq()|.
 
-wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
+wilder#filter_fuzzy()               *wilder#filter_fuzzy()*
                                     Deprecated~
-            Deprecated: Use |wilder#filter_fuzzy()|.
+            Deprecated: Use |wilder#fuzzy_filter()|.
 
 wilder#python_filter_fuzzy()        *wilder#python_filter_fuzzy()*
                                     Deprecated~


### PR DESCRIPTION
Help `Depcrecated` section below fix

```vimhelp
wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
                                    Deprecated~
            Deprecated: Use |wilder#filter_fuzzy()|.
```

Deprecated at wilder#filter_fuzzy().

```vim
" DEPRECATED: use wilder#fuzzy_filter()
function! wilder#filter_fuzzy() abort
  return call('wilder#fuzzy_filter', [])
endfunction
```

in [it](https://github.com/gelguy/wilder.nvim/blob/1c1549d3bbbea0e7a1bc7f56b72a5b9cd63da7a7/autoload/wilder.vim#L366-L369).