### PR TITLE
Fzy highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Due to statusline limitations, the wildmenu only fills up the width of the curre
 ```vim
 " 'highlighter' : applies highlighting to the candidates
 call wilder#set_option('renderer', wilder#wildmenu_renderer({
-      \ 'highlighter': wilder#query_highlighter(),
+      \ 'highlighter': wilder#basic_highlighter(),
       \ }))
 ```
 
@@ -190,7 +190,7 @@ An alternative theme which shows a spinner and the current number of items:
 
 ```vim
 call wilder#set_option('renderer', wilder#wildmenu_renderer({
-      \ 'highlighter': wilder#query_highlighter(),
+      \ 'highlighter': wilder#basic_highlighter(),
       \ 'separator': ' · ',
       \ 'left': [' ', wilder#wildmenu_spinner(), ' '],
       \ 'right': [' ', wilder#wildmenu_index()],
@@ -207,7 +207,7 @@ For Airline and Lightline users, `wilder#airline_theme()` and `wilder#lightline_
 call wilder#set_option('renderer', wilder#wildmenu_renderer(
       \ wilder#airline_theme({
       \   'highlights': {},
-      \   'highlighter': wilder#query_highlighter(),
+      \   'highlighter': wilder#basic_highlighter(),
       \   'separator': ' · ',
       \ })))
 ```
@@ -221,7 +221,7 @@ For Neovim 0.4+, `wilder#popupmenu_renderer()` can be used to draw the results o
 ```vim
 " 'highlighter' : applies highlighting to the candidates
 call wilder#set_option('renderer', wilder#popupmenu_renderer({
-      \ 'highlighter': wilder#query_highlighter(),
+      \ 'highlighter': wilder#basic_highlighter(),
       \ }))
 ```
 

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -86,6 +86,10 @@ function! wilder#make_hl(name, args, ...) abort
   return wilder#highlight#make_hl(a:name, a:args, a:000)
 endfunction
 
+function! wilder#make_temp_hl(name, args, ...) abort
+  return wilder#highlight#make_temp_hl(a:name, a:args, a:000)
+endfunction
+
 function! wilder#hl_with_attr(name, hl_group, ...) abort
   let l:attrs = {}
   for l:attr in a:000

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -635,9 +635,9 @@ function! wilder#popupmenu_devicons(...) abort
   return wilder#renderer#popupmenu_column#devicons#make(l:args)
 endfunction
 
-function! wilder#popupmenu_buffer_status(...) abort
+function! wilder#popupmenu_buffer_flags(...) abort
   let l:args = get(a:, 1, {})
-  return wilder#renderer#popupmenu_column#buffer_status#make(l:args)
+  return wilder#renderer#popupmenu_column#buffer_flags#make(l:args)
 endfunction
 
 " renderers

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -626,6 +626,11 @@ function! wilder#popupmenu_spinner(...) abort
   return wilder#renderer#popupmenu_column#spinner#make(l:args)
 endfunction
 
+function! wilder#popupmenu_buffer_status(...) abort
+  let l:args = get(a:, 1, {})
+  return wilder#renderer#popupmenu_column#buffer_status#make(l:args)
+endfunction
+
 " renderers
 
 function! wilder#renderer_mux(args)

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -98,14 +98,19 @@ function! wilder#hl_with_attr(name, hl_group, ...) abort
   return wilder#make_hl(a:name, a:hl_group, [{}, l:attrs, l:attrs])
 endfunction
 
+" DEPRECATED: use wilder#basic_highlighter()
 function! wilder#query_highlighter(...)
-  let l:opts = get(a:, 1, {})
-  return wilder#highlighter#query_highlighter(l:opts)
+  return call('wilder#basic_highlighter', a:000)
 endfunction
 
-" DEPRECATED: use wilder#query_highlighter()
+" DEPRECATED: use wilder#basic_highlighter()
 function! wilder#query_common_subsequence_spans(...)
-  return call('wilder#query_highlighter', a:000)
+  return call('wilder#basic_highlighter', a:000)
+endfunction
+
+function! wilder#basic_highlighter(...)
+  let l:opts = get(a:, 1, {})
+  return wilder#highlighter#basic_highlighter(l:opts)
 endfunction
 
 function! wilder#pcre2_highlighter(...)
@@ -119,8 +124,16 @@ function! wilder#pcre2_capture_spans(...)
 endfunction
 
 function! wilder#cpsm_highlighter(...)
+  return call('wilder#python_cpsm_highlighter', a:000)
+endfunction
+
+function! wilder#python_cpsm_highlighter(...)
   let l:opts = get(a:, 1, {})
-  return wilder#highlighter#cpsm_highlighter(l:opts)
+  return wilder#highlighter#python_cpsm_highlighter(l:opts)
+endfunction
+
+function! wilder#lua_fzy_highlighter(...)
+  return wilder#highlighter#lua_fzy_highlighter()
 endfunction
 
 " pipes

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -117,26 +117,50 @@ function! wilder#basic_highlighter(...)
   return wilder#highlighter#basic_highlighter(l:opts)
 endfunction
 
-function! wilder#pcre2_highlighter(...)
+function! wilder#vim_basic_highlighter(...) abort
+  let l:opts = get(a:, 1, {})
+  let l:opts.language = 'vim'
+  return wilder#highlighter#basic_highlighter(l:opts)
+endfunction
+
+function! wilder#python_basic_highlighter(...) abort
+  let l:opts = get(a:, 1, {})
+  let l:opts.language = 'python'
+  return wilder#highlighter#basic_highlighter(l:opts)
+endfunction
+
+function! wilder#pcre2_highlighter(...) abort
   let l:opts = get(a:, 1, {})
   return wilder#highlighter#pcre2_highlighter(l:opts)
 endfunction
 
+function! wilder#python_pcre2_highlighter(...) abort
+  let l:opts = get(a:, 1, {})
+  let l:opts.language = 'python'
+  return wilder#highlighter#pcre2_highlighter(l:opts)
+endfunction
+
+function! wilder#lua_pcre2_highlighter(...) abort
+  let l:opts = get(a:, 1, {})
+  let l:opts.language = 'lua'
+  return wilder#highlighter#pcre2_highlighter(l:opts)
+endfunction
+
 " DEPRECATED: use wilder#pcre2_highlighter()
-function! wilder#pcre2_capture_spans(...)
+function! wilder#pcre2_capture_spans(...) abort
   return call('wilder#pcre2_highlighter', a:000)
 endfunction
 
-function! wilder#cpsm_highlighter(...)
+function! wilder#cpsm_highlighter(...) abort
   return call('wilder#python_cpsm_highlighter', a:000)
 endfunction
 
-function! wilder#python_cpsm_highlighter(...)
+function! wilder#python_cpsm_highlighter(...) abort
   let l:opts = get(a:, 1, {})
   return wilder#highlighter#python_cpsm_highlighter(l:opts)
 endfunction
 
-function! wilder#lua_fzy_highlighter(...)
+function! wilder#lua_fzy_highlighter(...) abort
   return wilder#highlighter#lua_fzy_highlighter()
 endfunction
 
@@ -794,6 +818,8 @@ function! s:get_project_root(path, root_markers) abort
   return ''
 endfunction
 
+" DEPRECATED: This function is to be removed.
+" Use wilder#popupmenu_devicons() instead.
 function! wilder#result_draw_devicons()
   return wilder#result({
         \ 'draw': ['wilder#draw_devicons'],

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -626,6 +626,11 @@ function! wilder#popupmenu_spinner(...) abort
   return wilder#renderer#popupmenu_column#spinner#make(l:args)
 endfunction
 
+function! wilder#popupmenu_devicons(...) abort
+  let l:args = get(a:, 1, {})
+  return wilder#renderer#popupmenu_column#devicons#make(l:args)
+endfunction
+
 function! wilder#popupmenu_buffer_status(...) abort
   let l:args = get(a:, 1, {})
   return wilder#renderer#popupmenu_column#buffer_status#make(l:args)

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -823,9 +823,9 @@ function! wilder#cmdline#getcompletion_pipeline(opts) abort
     if has_key(a:opts, 'fuzzy_filter')
       let l:Filter = a:opts['fuzzy_filter']
     elseif l:use_python
-      let l:Filter = wilder#python_filter_fuzzy()
+      let l:Filter = wilder#python_fuzzy_filter()
     else
-      let l:Filter = wilder#filter_fuzzy()
+      let l:Filter = wilder#fuzzy_filter()
     endif
 
     let l:Fuzzy_filter = wilder#result({

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -46,6 +46,13 @@ function! s:prepare_fuzzy_completion(ctx, res) abort
     let l:prefix = ''
     let l:fuzzy_char = ''
     let a:res.match_arg = a:res.expand_arg
+  elseif a:res.expand ==# 'buffer'
+    " getcompletion() for buffers checks against the file name, but we want to
+    " check against the full path. Return all buffers and let the fuzzy filter
+    " remove the non-matching candidates.
+    let l:prefix = ''
+    let l:fuzzy_char = ''
+    let a:res.match_arg = a:res.expand_arg
   else
     let l:prefix = ''
     let l:fuzzy_char = strcharpart(a:res.expand_arg, 0, 1)
@@ -389,10 +396,11 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
     return getcompletion(l:expand_arg, 'behave')
   elseif a:res.expand ==# 'buffer'
     let l:buffers = getcompletion(l:expand_arg, 'buffer')
-    let l:buffers = map(l:buffers, {_, x -> fnamemodify(x, ':.')})
+    let l:buffers = map(l:buffers, {_, x -> fnamemodify(x, ':~:.')})
 
     let l:alt_file = expand('#')
     if !empty(l:alt_file)
+      let l:alt_file = fnamemodify(l:alt_file, ':~:.')
       let l:i = index(l:buffers, l:alt_file)
 
       if l:i > 0
@@ -878,7 +886,6 @@ let s:substitute_commands = {
       \ 'snomagic': v:true,
       \ 'global': v:true,
       \ 'vglobal': v:true,
-      \ '&': v:true,
       \ }
 
 function! wilder#cmdline#is_substitute_command(cmd) abort

--- a/autoload/wilder/highlight.vim
+++ b/autoload/wilder/highlight.vim
@@ -20,10 +20,15 @@ function! wilder#highlight#init_hl() abort
 endfunction
 
 function! wilder#highlight#make_hl(name, x, xs) abort
-  let l:name = s:make_hl(a:name, a:x, a:xs)
-  call filter(s:hl_list, {i, elem -> elem[0] !=# l:name})
-  call add(s:hl_list, [l:name, deepcopy(a:x), deepcopy(a:xs)])
-  return l:name
+  call s:make_hl(a:name, a:x, a:xs)
+  call filter(s:hl_list, {i, elem -> elem[0] !=# a:name})
+  call add(s:hl_list, [a:name, deepcopy(a:x), deepcopy(a:xs)])
+  return a:name
+endfunction
+
+function! wilder#highlight#make_temp_hl(name, x, xs) abort
+  call s:make_hl(a:name, a:x, a:xs)
+  return a:name
 endfunction
 
 function! s:make_hl(name, x, xs) abort
@@ -34,7 +39,7 @@ function! s:make_hl(name, x, xs) abort
     let l:x = s:combine_hl_list(l:x, l:y)
   endfor
 
-  return s:make_hl_from_list(a:name, l:x)
+  call s:make_hl_from_list(a:name, l:x)
 endfunction
 
 function! s:to_hl_list(x) abort
@@ -199,7 +204,6 @@ function! s:make_hl_from_list(name, args) abort
   endif
 
   exe l:cmd
-  return a:name
 endfunction
 
 function! s:get_attrs_as_list(attrs) abort

--- a/autoload/wilder/main.vim
+++ b/autoload/wilder/main.vim
@@ -193,10 +193,6 @@ function! s:pre_hook() abort
   if has_key(s:opts.renderer, 'pre_hook')
     call s:opts.renderer.pre_hook({})
   endif
-
-  " create highlight before and after since there might be renderer-defined
-  " highlights which depend on existing highlights
-  call wilder#highlight#init_hl()
 endfunction
 
 function! s:post_hook() abort

--- a/autoload/wilder/main.vim
+++ b/autoload/wilder/main.vim
@@ -177,6 +177,10 @@ function! wilder#main#stop() abort
     unlet s:replaced_cmdline
   endif
 
+  if exists('s:keep_reject_completion')
+    unlet s:keep_reject_completion
+  endif
+
   if !s:hidden
     call s:post_hook()
   endif
@@ -223,8 +227,9 @@ function! s:do(check) abort
   let l:has_completion = exists('s:completion') && l:input ==# s:completion
   let l:is_new_input = !exists('s:previous_cmdline')
   let l:input_changed = exists('s:previous_cmdline') && s:previous_cmdline !=# l:input
+  let l:should_keep_reject_completion = exists('s:keep_reject_completion') && s:keep_reject_completion ==# l:input
 
-  if !l:has_completion
+  if !l:has_completion && !l:should_keep_reject_completion
     if exists('s:completion')
       unlet s:completion
     endif
@@ -232,6 +237,12 @@ function! s:do(check) abort
     if exists('s:replaced_cmdline')
       unlet s:replaced_cmdline
     endif
+
+    let s:completion_stack = []
+  endif
+
+  if !l:should_keep_reject_completion && exists('s:keep_reject_completion')
+    unlet s:keep_reject_completion
   endif
 
   if !exists('s:previous_cmdline') || l:input_changed
@@ -662,6 +673,7 @@ function! wilder#main#reject_completion() abort
     endif
 
     let s:previous_cmdline = l:cmdline
+    let s:keep_reject_completion = l:cmdline
     let s:result = {'value': []}
     let s:selected = -1
     let s:clear_selection = 1

--- a/autoload/wilder/main.vim
+++ b/autoload/wilder/main.vim
@@ -5,6 +5,7 @@ let s:init = 0
 let s:active = 0
 let s:hidden = 0
 let s:session_id = 0
+let s:result_session_id = -1
 let s:run_id = 0
 let s:result_run_id = -1
 let s:draw_done = 0
@@ -282,6 +283,7 @@ function! wilder#main#on_finish(ctx, x) abort
   endif
 
   let s:result_run_id = a:ctx.run_id
+  let s:result_session_id = a:ctx.session_id
 
   let l:result = (a:x is v:false || a:x is v:true)
         \ ? {'value': []}
@@ -398,6 +400,7 @@ function! s:draw(...) abort
             \ 'direction': l:direction,
             \ 'run_id': s:result_run_id,
             \ 'done': s:run_id == s:result_run_id,
+            \ 'session_id': s:result_session_id,
             \ }
       let s:clear_selection = 0
 

--- a/autoload/wilder/pipe/python_fuzzy_delimiter.vim
+++ b/autoload/wilder/pipe/python_fuzzy_delimiter.vim
@@ -64,7 +64,7 @@ function! s:fuzzy_delimiter(args, ctx, x) abort
     endif
 
     if l:first
-      let l:start_at_boundary =  get(a:args, 'start_at_boundary', 0)
+      let l:start_at_boundary =  get(a:args, 'start_at_boundary', 1)
 
       if l:escaped || l:char ==# toupper(l:char)
         let l:res .= '(' . l:char . ')'

--- a/autoload/wilder/pipe/python_fuzzy_delimiter.vim
+++ b/autoload/wilder/pipe/python_fuzzy_delimiter.vim
@@ -64,12 +64,16 @@ function! s:fuzzy_delimiter(args, ctx, x) abort
     endif
 
     if l:first
+      let l:start_at_boundary =  get(a:args, 'start_at_boundary', 0)
+
       if l:escaped || l:char ==# toupper(l:char)
         let l:res .= '(' . l:char . ')'
-      elseif get(a:args, 'start_at_boundary', 1)
-        let l:res .= '(?:(?:(?<=' . l:delimiter . ')|\b)('. l:char . ')|(' . toupper(l:char) . '))'
       else
-        let l:res .= '('. l:char . '|' . toupper(l:char) . ')'
+        let l:res .= '(?:(?:(?<=' . l:delimiter . ')|\b)('. l:char . ')|(' . toupper(l:char) . '))'
+      endif
+
+      if !l:start_at_boundary
+        let l:res = l:word_or_delimiter . '*' . l:res
       endif
 
       let l:first = 0

--- a/autoload/wilder/pipe/python_fuzzy_match.vim
+++ b/autoload/wilder/pipe/python_fuzzy_match.vim
@@ -13,7 +13,7 @@ function! s:fuzzy_match(args, ctx, x) abort
     let l:word = '\w'
   endif
 
-  if get(a:args, 'start_at_boundary', 0)
+  if get(a:args, 'start_at_boundary', 1)
     " starts with word boundary or is preceded by a non-word character
     let l:res = '(?:\b|^|(?!' . l:word  . '))'
   else

--- a/autoload/wilder/pipe/python_fuzzy_match.vim
+++ b/autoload/wilder/pipe/python_fuzzy_match.vim
@@ -13,11 +13,11 @@ function! s:fuzzy_match(args, ctx, x) abort
     let l:word = '\w'
   endif
 
-  if get(a:args, 'start_at_boundary', 1)
+  if get(a:args, 'start_at_boundary', 0)
     " starts with word boundary or is preceded by a non-word character
     let l:res = '(?:\b|^|(?!' . l:word  . '))'
   else
-    let l:res = ''
+    let l:res = '(?:' . l:word . ')*'
   endif
 
   let l:chars = split(a:x, '\zs')

--- a/autoload/wilder/render.vim
+++ b/autoload/wilder/render.vim
@@ -2,7 +2,7 @@ scriptencoding utf-8
 
 let s:has_strtrans_issue = strdisplaywidth('') != strdisplaywidth(strtrans(''))
 
-function! wilder#render#draw_x(ctx, result, i)
+function! wilder#render#draw_x(ctx, result, i) abort
   let l:x = a:result.value[a:i]
 
   if has_key(a:result, 'draw')
@@ -180,7 +180,9 @@ function! wilder#render#chunks_displaywidth(chunks) abort
   let l:width = 0
 
   for l:chunk in a:chunks
-    let l:width += strdisplaywidth(l:chunk[0])
+    if !empty(l:chunk)
+      let l:width += strdisplaywidth(l:chunk[0])
+    endif
   endfor
 
   return l:width

--- a/autoload/wilder/renderer/mux.vim
+++ b/autoload/wilder/renderer/mux.vim
@@ -1,17 +1,48 @@
 function! wilder#renderer#mux#make(opts) abort
+  " convert from dict to list
+  " e.g. {':': R1, '/': R2} to [[':', R1], ['/': R2]]
+  if type(a:opts) is v:t_dict
+    let l:rs = []
+
+    for l:key in keys(a:opts)
+      " put substitute check in front of : check
+      " put ? check in front of / check since / covers both / and ?
+      if l:key ==# 'substitute' || l:key ==# '?'
+        call insert(l:rs, [l:key, a:opts[l:key]])
+      else
+        call add(l:rs, [l:key, a:opts[l:key]])
+      endif
+    endfor
+  else
+    let l:rs = a:opts
+  endif
+
+  " convert strings ':' to cmdtype checks
+  let l:i = 0
+  while l:i < len(l:rs)
+    let l:r = l:rs[l:i]
+
+    let l:Check = l:r[0]
+
+    if type(l:Check) is v:t_string
+      if l:Check ==# 'substitute'
+        let l:r[0] = funcref('s:is_substitute_command')
+      elseif l:Check ==# '/'
+        let l:r[0] = {-> getcmdtype() ==# '/' || getcmdtype() ==# '?'}
+      else
+        let l:r[0] = s:cmdtype_check(l:Check)
+      endif
+    endif
+
+    let l:i += 1
+  endwhile
+
   let l:state = {
-        \ ':': a:opts[':'],
-        \ '/': a:opts['/'],
-        \ '_current': 0,
+        \ 'current': 0,
+        \ 'timer': -1,
+        \ 'active': 0,
+        \ 'renderers': l:rs
         \ }
-
-  if has_key(a:opts, 'substitute')
-    let l:state._substitute = a:opts.substitute
-  endif
-
-  if !has_key(a:opts, '?') && has_key(a:opts, '/')
-    let l:state['?'] = a:opts['/']
-  endif
 
   return {
         \ 'render': {ctx, result -> s:render(l:state, ctx, result)},
@@ -20,31 +51,52 @@ function! wilder#renderer#mux#make(opts) abort
         \ }
 endfunction
 
-function! s:render(state, ctx, result)
-  let l:cmdtype = getcmdtype()
-  let l:renderer = has_key(a:state, l:cmdtype) ?
-        \ a:state[l:cmdtype] :
-        \ 0
+function! s:cmdtype_check(type)
+  return {-> getcmdtype() ==# a:type}
+endfunction
 
-  if l:cmdtype ==# ':'
-    let l:parsed = wilder#cmdline#parse(getcmdline())
-
-    if wilder#cmdline#is_substitute_command(l:parsed.cmd) &&
-          \ has_key(a:state, '_substitute')
-      let l:renderer = a:state._substitute
-    endif
+function! s:is_substitute_command(ctx) abort
+  if getcmdtype() !=# ':'
+    return 0
   endif
 
-  if l:renderer isnot a:state._current
-    if a:state._current isnot 0
-      call a:state._current.post_hook({})
+  let l:res = wilder#cmdline#parse(getcmdline())
+
+  return wilder#cmdline#is_substitute_command(l:res.cmd)
+endfunction
+
+function! s:get_renderer(renderers) abort
+  for [l:Check, l:renderer] in a:renderers
+    if l:Check({})
+      return l:renderer
+    endif
+  endfor
+
+  return 0
+endfunction
+
+function! s:start_render(state, ctx, result)
+  call timer_stop(a:state.timer)
+  let a:state.timer = timer_start(0, {-> s:render(a:state, a:ctx, a:result)})
+endfunction
+
+function! s:render(state, ctx, result)
+  if !a:state.active
+    return
+  endif
+
+  let l:renderer = s:get_renderer(a:state.renderers)
+
+  if l:renderer isnot a:state.current
+    if a:state.current isnot 0 && has_key(a:state.current, 'post_hook')
+      call a:state.current.post_hook({})
     endif
 
-    if l:renderer isnot 0
+    if l:renderer isnot 0 && has_key(l:renderer, 'pre_hook')
       call l:renderer.pre_hook({})
     endif
 
-    let a:state._current = l:renderer
+    let a:state.current = l:renderer
   endif
 
   if l:renderer is 0
@@ -55,15 +107,11 @@ function! s:render(state, ctx, result)
 endfunction
 
 function! s:pre_hook(state, ctx)
-  let l:cmdtype = getcmdtype()
+  let a:state.active = 1
 
-  if has_key(a:state, l:cmdtype)
-    let l:renderer = a:state[l:cmdtype]
-  else
-    let l:renderer = 0
-  endif
+  let l:renderer = s:get_renderer(a:state.renderers)
 
-  let a:state._current = l:renderer
+  let a:state.current = l:renderer
 
   if l:renderer is 0
     return
@@ -75,13 +123,15 @@ function! s:pre_hook(state, ctx)
 endfunction
 
 function! s:post_hook(state, ctx)
-  let l:renderer = a:state._current
+  let a:state.active = 0
+
+  let l:renderer = a:state.current
 
   if l:renderer is 0
     return
   endif
 
-  let a:state._current = 0
+  let a:state.current = 0
 
   if has_key(l:renderer, 'post_hook')
     call l:renderer.post_hook(a:ctx)

--- a/autoload/wilder/renderer/popupmenu.vim
+++ b/autoload/wilder/renderer/popupmenu.vim
@@ -131,6 +131,14 @@ function! s:render(state, ctx, result) abort
     let a:state.page = [-1, -1]
   endif
 
+  if a:state.page != [-1, -1]
+    if a:state.page[0] > len(a:result.value)
+      let a:state.page = [-1, -1]
+    elseif a:state.page[1] > len(a:result.value)
+      let a:state.page[1] = len(a:result.value) - 1
+    endif
+  endif
+
   let l:page = s:make_page(a:state, a:ctx, a:result)
   let a:ctx.page = l:page
   let a:state.page = l:page

--- a/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
+++ b/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
@@ -57,7 +57,7 @@ function! s:buffer_status(state, ctx, result) abort
   while l:i <= l:end
     let l:index = l:i - l:start
 
-    let l:x = simplify(a:result.value[l:i])
+    let l:x = fnamemodify(simplify(a:result.value[l:i]), ':~')
 
     if a:state.cache.has_key(l:x)
       let l:buffer_status[l:index] = a:state.cache.get(l:x)

--- a/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
+++ b/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
@@ -1,5 +1,5 @@
 function! wilder#renderer#popupmenu_column#buffer_flags#make(opts) abort
-  let l:flags = get(a:opts, 'flags', '1 %+ ')
+  let l:flags = get(a:opts, 'flags', '1 %a-+ ')
 
   if empty(l:flags)
     return {-> ''}
@@ -98,6 +98,13 @@ function! s:buffer_status(state, ctx, result) abort
       elseif l:char ==# '-'
         let l:status .= nvim_buf_get_option(l:bufnr, 'readonly') ? '=' :
               \ !nvim_buf_get_option(l:bufnr, 'modifiable') ? '-' : ' '
+      elseif l:char ==# 'a'
+        if bufloaded(l:bufnr)
+          let l:is_active = !empty(win_findbuf(l:bufnr))
+          let l:status .= l:is_active ? 'a' : 'h'
+        else
+          let l:status .= ' '
+        endif
       endif
 
       let l:chunks = [[l:status, l:hl, l:selected_hl]]

--- a/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
+++ b/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
@@ -1,7 +1,23 @@
-function! wilder#renderer#popupmenu_column#buffer_status#make(opts) abort
-  let l:state = copy(a:opts)
-  let l:state.cache = wilder#cache#cache()
-  let l:state.run_id = -1
+function! wilder#renderer#popupmenu_column#buffer_flags#make(opts) abort
+  let l:flags = get(a:opts, 'flags', '1 %+ ')
+
+  if empty(l:flags)
+    return {-> ''}
+  endif
+
+  let l:state = {
+        \ 'flags': l:flags,
+        \ 'cache': wilder#cache#cache(),
+        \ 'session_id': -1,
+        \ }
+
+  if has_key(a:opts, 'hl')
+    let l:state.hl = a:opts.hl
+  endif
+
+  if has_key(a:opts, 'selected_hl')
+    let l:state.selected_hl = a:opts.selected_hl
+  endif
 
   return {ctx, result -> s:buffer_status(l:state, ctx, result)}
 endfunction
@@ -13,16 +29,12 @@ function! s:buffer_status(state, ctx, result) abort
     return ''
   endif
 
-  let l:flags = get(a:state, 'flags', '1 %+ ')
+  let l:flags = a:state.flags
 
-  if empty(l:flags)
-    return ''
-  endif
-
-  let l:run_id = a:ctx.run_id
-  if a:state.run_id != l:run_id
+  let l:session_id = a:ctx.session_id
+  if a:state.session_id != l:session_id
     call a:state.cache.clear()
-    let a:state.run_id = l:run_id
+    let a:state.session_id = l:session_id
   endif
 
   let [l:start, l:end] = a:ctx.page

--- a/autoload/wilder/renderer/popupmenu_column/buffer_status.vim
+++ b/autoload/wilder/renderer/popupmenu_column/buffer_status.vim
@@ -1,0 +1,102 @@
+function! wilder#renderer#popupmenu_column#buffer_status#make(opts) abort
+  let l:state = copy(a:opts)
+  let l:state.cache = wilder#cache#cache()
+  let l:state.run_id = -1
+
+  return {ctx, result -> s:buffer_status(l:state, ctx, result)}
+endfunction
+
+function! s:buffer_status(state, ctx, result) abort
+  let l:expand = get(a:result.data, 'cmdline.expand', '')
+
+  if l:expand !=# 'buffer' && l:expand !=# 'file'
+    return ''
+  endif
+
+  let l:flags = get(a:state, 'flags', '1 %+ ')
+
+  if empty(l:flags)
+    return ''
+  endif
+
+  let l:run_id = a:ctx.run_id
+  if a:state.run_id != l:run_id
+    call a:state.cache.clear()
+    let a:state.run_id = l:run_id
+  endif
+
+  let [l:start, l:end] = a:ctx.page
+  " [current, modified]
+  let l:buffer_status = repeat([0], l:end - l:start + 1)
+
+  let l:width = len(l:flags)
+
+  if stridx(l:flags, '1') != -1
+    let l:bufnr_width = strdisplaywidth(bufnr('$'))
+    let l:width += l:bufnr_width - 1
+  endif
+
+  let l:hl = get(a:state, 'hl', a:ctx.highlights['default'])
+  let l:selected_hl = get(a:state, 'selected_hl', a:ctx.highlights['selected'])
+
+  let l:empty_chunks = [[repeat(' ', l:width), l:hl, l:selected_hl]]
+
+  let l:i = l:start
+  while l:i <= l:end
+    let l:index = l:i - l:start
+
+    let l:x = simplify(a:result.value[l:i])
+
+    if a:state.cache.has_key(l:x)
+      let l:buffer_status[l:index] = a:state.cache.get(l:x)
+      let l:i += 1
+      continue
+    endif
+
+    let l:bufnr = bufnr('^' . l:x . '$')
+
+    if l:bufnr == -1
+      call a:state.cache.set(l:x, l:empty_chunks)
+      let l:buffer_status[l:index] = l:empty_chunks
+      let l:i += 1
+      continue
+    endif
+
+    let l:status = ''
+
+    let l:j = 0
+    while l:j < l:width
+      let l:char = l:flags[l:j]
+
+      if l:char ==# ' '
+        let l:status .= ' '
+      elseif l:char ==# '1'
+        let l:status .= repeat(' ', l:bufnr_width - strdisplaywidth(l:bufnr))
+        let l:status .= l:bufnr
+      elseif l:char ==# '%'
+        if l:bufnr == bufnr('%')
+          let l:status .= '%'
+        elseif l:bufnr == bufnr('#')
+          let l:status .= '#'
+        else
+          let l:status .= ' '
+        endif
+      elseif l:char ==# '+'
+        let l:status .= nvim_buf_get_option(l:bufnr, 'modified') ?  '+' : ' '
+      elseif l:char ==# '-'
+        let l:status .= nvim_buf_get_option(l:bufnr, 'readonly') ? '=' :
+              \ !nvim_buf_get_option(l:bufnr, 'modifiable') ? '-' : ' '
+      endif
+
+      let l:chunks = [[l:status, l:hl, l:selected_hl]]
+      call a:state.cache.set(l:x, l:chunks)
+      let l:buffer_status[l:index] = l:chunks
+
+      let l:j += 1
+    endwhile
+
+    let l:i += 1
+  endwhile
+
+  return l:buffer_status
+endfunction

--- a/autoload/wilder/renderer/popupmenu_column/devicons.vim
+++ b/autoload/wilder/renderer/popupmenu_column/devicons.vim
@@ -1,0 +1,46 @@
+function! wilder#renderer#popupmenu_column#devicons#make(opts) abort
+  let l:state = {
+        \ 'padding': get(a:opts, 'padding', [0, 1]),
+        \ }
+
+  return {ctx, result -> s:devicons(l:state, ctx, result)}
+endfunction
+
+function! s:devicons(state, ctx, result) abort
+  let l:expand = get(a:result.data, 'cmdline.expand', '')
+
+  if l:expand !=# 'file' &&
+        \ l:expand !=# 'file_in_path' &&
+        \ l:expand !=# 'dir' &&
+        \ l:expand !=# 'shellcmd' &&
+        \ l:expand !=# 'buffer'
+    return ''
+  endif
+
+  let l:left_padding = repeat(' ', a:state.padding[0])
+  let l:right_padding = repeat(' ', a:state.padding[1])
+
+  let l:slash = !has('win32') && !has('win64')
+        \ ? '/'
+        \ : &shellslash
+        \ ? '/'
+        \ : '\'
+
+  let [l:start, l:end] = a:ctx.page
+
+  let l:icons = repeat([0], l:end - l:start + 1)
+
+  let l:i = l:start
+  while l:i <= l:end
+    let l:x = a:result.value[l:i]
+
+    let l:is_dir = l:x[-1:] ==# l:slash || l:x[-1:] ==# '/'
+
+    let l:index = l:i - l:start
+    let l:icons[l:index] = [[l:left_padding . WebDevIconsGetFileTypeSymbol(l:x, l:is_dir) . l:right_padding]]
+
+    let l:i += 1
+  endwhile
+
+  return l:icons
+endfunction

--- a/autoload/wilder/renderer/popupmenu_column/devicons.vim
+++ b/autoload/wilder/renderer/popupmenu_column/devicons.vim
@@ -1,7 +1,17 @@
 function! wilder#renderer#popupmenu_column#devicons#make(opts) abort
+  let l:padding = get(a:opts, 'padding', [0, 1])
   let l:state = {
-        \ 'padding': get(a:opts, 'padding', [0, 1]),
+        \ 'session_id': -1,
+        \ 'cache': wilder#cache#cache(),
+        \ 'left_padding': repeat(' ', l:padding[0]),
+        \ 'right_padding': repeat(' ', l:padding[1]),
         \ }
+
+  if !has_key(a:opts, 'get_icon')
+    let l:state.get_icon = 'WebDevIconsGetFileTypeSymbol'
+  else
+    let l:state.get_icon = a:opts.get_icon
+  endif
 
   return {ctx, result -> s:devicons(l:state, ctx, result)}
 endfunction
@@ -17,8 +27,11 @@ function! s:devicons(state, ctx, result) abort
     return ''
   endif
 
-  let l:left_padding = repeat(' ', a:state.padding[0])
-  let l:right_padding = repeat(' ', a:state.padding[1])
+  let l:session_id = a:ctx.session_id
+  if a:state.session_id != l:session_id
+    call a:state.cache.clear()
+    let a:state.session_id = l:session_id
+  endif
 
   let l:slash = !has('win32') && !has('win64')
         \ ? '/'
@@ -30,17 +43,49 @@ function! s:devicons(state, ctx, result) abort
 
   let l:icons = repeat([0], l:end - l:start + 1)
 
+  let l:Get_icon = a:state.get_icon
+  if type(l:Get_icon) is v:t_string
+    let l:Get_icon = function(l:Get_icon)
+  endif
+
   let l:i = l:start
   while l:i <= l:end
+    let l:index = l:i - l:start
+
     let l:x = a:result.value[l:i]
+
+    if a:state.cache.has_key(l:x)
+      let l:icons[l:index] = a:state.cache.get(l:x)
+
+      let l:i += 1
+      continue
+    endif
 
     let l:is_dir = l:x[-1:] ==# l:slash || l:x[-1:] ==# '/'
 
-    let l:index = l:i - l:start
-    let l:icons[l:index] = [[l:left_padding . WebDevIconsGetFileTypeSymbol(l:x, l:is_dir) . l:right_padding]]
+    let l:icon = l:Get_icon(l:x, l:is_dir)
+
+    let l:chunks = [[a:state.left_padding . l:icon . a:state.right_padding]]
+    call a:state.cache.set(l:x, l:chunks)
+
+    let l:icons[l:index] = l:chunks
 
     let l:i += 1
   endwhile
 
   return l:icons
+endfunction
+
+function! s:get_guibg(hl) abort
+  let l:gui_colors = wilder#highlight#get_hl(a:hl)[2]
+
+  return get(l:gui_colors, 'reverse', 0) || get(l:gui_colors, 'standout', 0) ?
+        \ l:gui_colors.foreground :
+        \ l:gui_colors.background
+endfunction
+
+function! s:make_temp_hl(hl, guibg, selected) abort
+  let l:name = a:selected ? 'WilderDeviconsSelected_' : 'WilderDevicons_'
+  return wilder#make_temp_hl(l:name . a:hl, a:hl,
+        \ [{}, {}, {'background': a:guibg}])
 endfunction

--- a/autoload/wilder/renderer/popupmenu_column/scrollbar.vim
+++ b/autoload/wilder/renderer/popupmenu_column/scrollbar.vim
@@ -1,8 +1,5 @@
 function! wilder#renderer#popupmenu_column#scrollbar#make(opts) abort
-  let l:state = {
-        \ 'cache': wilder#cache#cache(),
-        \ 'run_id': -1,
-        \ }
+  let l:state = {}
 
   let l:thumb_char = get(a:opts, 'thumb_char', '█')
   let l:thumb_hl = get(a:opts, 'thumb_hl', 'PmenuThumb')
@@ -12,46 +9,37 @@ function! wilder#renderer#popupmenu_column#scrollbar#make(opts) abort
   let l:state['thumb_chunk'] = [l:thumb_char, l:thumb_hl]
   let l:state['scrollbar_chunk'] = [l:scrollbar_char, l:scrollbar_hl]
 
-  return {ctx, result, i -> s:scrollbar(l:state, ctx, result, i)}
+  return {ctx, result -> s:scrollbar(l:state, ctx, result)}
 endfunction
 
-function! s:scrollbar(state, ctx, result, i) abort
-  if a:state.run_id != a:ctx.run_id
-    call a:state.cache.clear()
-  endif
-
-  let l:page = a:ctx.page
-
-  if l:page == [-1, -1]
-    return ''
-  endif
-
-  let [l:start, l:end] = l:page
+function! s:scrollbar(state, ctx, result) abort
+  let [l:start, l:end] = a:ctx.page
   let l:num_candidates = len(a:result.value)
   let l:pum_height = l:end - l:start + 1
 
   if l:pum_height == l:num_candidates
-    return ''
+    return []
   endif
 
-  let l:cache = a:state['cache']
+  let l:thumb_start = float2nr(1.0 * l:start * l:pum_height / l:num_candidates)
+  let l:thumb_size = float2nr(1.0 * l:pum_height * l:pum_height / l:num_candidates) + 1
+  let l:thumb_end = l:thumb_start + l:thumb_size
 
-  let l:key = l:start . ' ' . l:end . ' ' . l:num_candidates . ' ' . l:pum_height
-
-  if !l:cache.has_key(l:key)
-    let l:thumb_start = floor(1.0 * l:start * l:pum_height / l:num_candidates)
-    let l:thumb_size = floor(1.0 * l:pum_height * l:pum_height / l:num_candidates) + 1
-    let l:thumb_end = l:thumb_start + l:thumb_size
-
-    call l:cache.set(l:key, [l:thumb_start, l:thumb_end])
-  else
-    let [l:thumb_start, l:thumb_end] = l:cache.get(l:key)
+  " Due to floating point rounding, thumb can exceed pum_height.
+  " Adjust the thumb back 1 row so that visually the thumb size remains fixed.
+  " The position of the thumb will be wrong but the fixed thumb size is more
+  " important.
+  if l:thumb_end > l:pum_height
+    let l:thumb_start -= 1
+    let l:thumb_end -= 1
   endif
 
-  let l:row = a:i - l:start
-  if l:thumb_start <= l:row && l:thumb_end > l:row
-    return [a:state['thumb_chunk']]
-  endif
+  let l:thumb_chunk = a:state['thumb_chunk']
+  let l:scrollbar_chunk = a:state['scrollbar_chunk']
 
-  return [a:state['scrollbar_chunk']]
+  let l:before_thumb_chunks = repeat([[l:scrollbar_chunk]], l:thumb_start)
+  let l:thumb_chunks = repeat([[l:thumb_chunk]], l:thumb_size)
+  let l:after_thumb_chunks = repeat([[l:scrollbar_chunk]], l:pum_height - l:thumb_end)
+
+  return l:before_thumb_chunks + l:thumb_chunks + l:after_thumb_chunks
 endfunction

--- a/autoload/wilder/renderer/popupmenu_column/spinner.vim
+++ b/autoload/wilder/renderer/popupmenu_column/spinner.vim
@@ -46,11 +46,5 @@ function! s:spinner(state, ctx, result, i) abort
     let l:frame = a:state.frames[l:frame_number]
   endif
 
-  if a:ctx.selected == a:i
-    let l:hl = get(a:state, 'selected_hl', a:ctx.highlights['selected'])
-  else
-    let l:hl = get(a:state, 'hl', a:ctx.highlights['default'])
-  endif
-
-  return [[l:frame, l:hl]]
+  return [[l:frame]]
 endfunction

--- a/autoload/wilder/renderer/popupmenu_column/spinner.vim
+++ b/autoload/wilder/renderer/popupmenu_column/spinner.vim
@@ -26,17 +26,13 @@ function! wilder#renderer#popupmenu_column#spinner#make(opts) abort
   endif
 
   return {
-        \ 'value': {ctx, result, i -> s:spinner(l:state, ctx, result, i)},
+        \ 'value': {ctx, result -> s:spinner(l:state, ctx, result)},
         \ }
 endfunction
 
-function! s:spinner(state, ctx, result, i) abort
+function! s:spinner(state, ctx, result) abort
   let [l:start, l:end] = a:ctx.page
-
-  if (a:state.align ==# 'bottom' && a:i != l:end) ||
-        \ (a:state.align ==# 'top' && a:i != l:start)
-    return ' '
-  endif
+  let l:height = l:end - l:start + 1
 
   let l:frame_number = a:state.spinner.spin(a:ctx, a:result)
 
@@ -46,5 +42,13 @@ function! s:spinner(state, ctx, result, i) abort
     let l:frame = a:state.frames[l:frame_number]
   endif
 
-  return [[l:frame]]
+  let l:column_chunks = repeat([[['']]], l:height)
+
+  if a:state.align ==# 'bottom'
+    let l:column_chunks[-1] = [[l:frame]]
+  else
+    let l:column_chunks[0] = [[l:frame]]
+  endif
+
+  return l:column_chunks
 endfunction

--- a/autoload/wilder/renderer/wildmenu.vim
+++ b/autoload/wilder/renderer/wildmenu.vim
@@ -74,6 +74,14 @@ function! wilder#renderer#wildmenu#make_hl_chunks(state, width, ctx, result) abo
     let a:state.page = [-1, -1]
   endif
 
+  if a:state.page != [-1, -1]
+    if a:state.page[0] > len(a:result.value)
+      let a:state.page = [-1, -1]
+    elseif a:state.page[1] > len(a:result.value)
+      let a:state.page[1] = len(a:result.value) - 1
+    endif
+  endif
+
   let l:space_used = wilder#renderer#wildmenu#item_len(
         \ a:state.left,
         \ a:ctx,

--- a/autoload/wilder/renderer/wildmenu_item/separator.vim
+++ b/autoload/wilder/renderer/wildmenu_item/separator.vim
@@ -30,7 +30,7 @@ function! s:hl(name, from, to) abort
   call s:get_hl(l:colors[1], l:from_hl[1], l:to_hl[1], l:normal_hl[1], 1)
   call s:get_hl(l:colors[2], l:from_hl[2], l:to_hl[2], l:normal_hl[2], 0)
 
-  call wilder#make_hl(a:name, l:colors)
+  call wilder#make_temp_hl(a:name, l:colors)
 endfunction
 
 function! s:get_hl(hl, from_hl, to_hl, default_hl, is_cterm) abort

--- a/autoload/wilder/renderer/wildmenu_theme.vim
+++ b/autoload/wilder/renderer/wildmenu_theme.vim
@@ -101,22 +101,22 @@ function! s:theme(opts, namespace, hls) abort
   elseif l:use_powerline_symbols == 1
     let l:separators = [
           \ wilder#powerline_separator(l:powerline_symbols[0],
-          \   l:highlights['mode'], l:highlights['left_arrow2'],  'Left'),
+          \   l:highlights['mode'], l:highlights['left_arrow2'],  a:namespace . 'Left'),
           \ wilder#powerline_separator(l:powerline_symbols[0],
-          \   l:highlights['left_arrow2'], l:highlights['default'],  'Left2'),
+          \   l:highlights['left_arrow2'], l:highlights['default'],  a:namespace . 'Left2'),
           \ wilder#powerline_separator(l:powerline_symbols[1],
-          \   l:highlights['right_arrow2'], l:highlights['default'],  'Right'),
+          \   l:highlights['right_arrow2'], l:highlights['default'],  a:namespace . 'Right'),
           \ wilder#powerline_separator(l:powerline_symbols[1],
-          \   l:highlights['index'], l:highlights['right_arrow2'],  'Right2'),
+          \   l:highlights['index'], l:highlights['right_arrow2'],  a:namespace . 'Right2'),
           \ ]
   else
     let l:separators = [
           \ wilder#powerline_separator(l:powerline_symbols[0],
-          \   l:highlights['mode'], l:highlights['default'],  'Left'),
+          \   l:highlights['mode'], l:highlights['default'],  a:namespace . 'Left'),
           \ '',
           \ '',
           \ wilder#powerline_separator(l:powerline_symbols[1],
-          \   l:highlights['index'], l:highlights['default'],  'Right2'),
+          \   l:highlights['index'], l:highlights['default'],  a:namespace . 'Right2'),
           \ ]
   endif
 

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1719,10 +1719,10 @@ wilder#popupmenu_devicons([{options}])
 
             Default: [0, 1]
 
-                                    *wilder#popupmenu_buffer_status()*
-wilder#popupmenu_buffer_status([{options}])
+                                    *wilder#popupmenu_buffer_flags()*
+wilder#popupmenu_buffer_flags([{options}])
                                     wilder#popupmenu_renderer() column~
-            Adds buffer status information.
+            Adds buffer flag information from |:ls|.
 
             {options} is a dictionary with keys:
             `flags`

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1860,8 +1860,8 @@ wilder#start_from_normal_mode()     *wilder#start_from_normal_mode()*
             nnoremap <expr> : wilder#start_from_normal_mode() . ':'
 <
 
-wilder#make_hl({name}, {args}, [, {args1}, ..., {argsN}])
                                     *wilder#make_hl()*
+wilder#make_hl({name}, {args}, [, {args1}, ..., {argsN}])
             Helper function to create a highlight group. Creates a highlight
             group with the given {name} based on {args}.
 
@@ -1974,8 +1974,16 @@ wilder#make_hl({name}, {args}, [, {args1}, ..., {argsN}])
                     \ [{}, {}, {'underline': 1, 'reverse': 0}])
 <
 
-wilder#hl_with_attr({name}, {hl_group}, {attr} [, ..., {attrN}])
+                                    *wilder#make_temp__hl()*
+wilder#make_temp_hl({name}, {args}, [, {args1}, ..., {argsN}])
+            Same as |wilder#make_hl()|, except the highlight groups are not
+            recreated each time wilder is started.
+
+            This should be used for highlights which are dynamically created
+            e.g. in a pre-hook.
+
                                     *wilder#hl_with_attr()*
+wilder#hl_with_attr({name}, {hl_group}, {attr} [, ..., {attrN}])
             Helper function to create a new |highlight-group| named {name} by
             applying attributes to {hl_group}. Attributes can be turned off by
             prefixing it with 'no'.

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -56,14 +56,15 @@ wilder#set_option({dict})
             call wilder#set_option({'foo': 'bar'})
 <
 
+The options for `wilder` are:
 
-modes                               *wilder-option-modes*
+`modes`                             *wilder-option-modes*
             List of modes which wilder will be active in.
             Possible elements: '/', '?' and ':'
 
             Default: ['/', '?']
 
-use_cmdlinechanged                  *wilder-option-use_cmdlinechanged*
+`use_cmdlinechanged`                *wilder-option-use_cmdlinechanged*
             If true, wilder will refresh queries when the |CmdlineChanged|
             autocommand is triggered.
             Otherwise it will use a |timer| to check whether the cmdline has
@@ -72,14 +73,14 @@ use_cmdlinechanged                  *wilder-option-use_cmdlinechanged*
 
             Default: exists('##CmdlineChanged')
 
-interval                            *wilder-option-interval*
+`interval`                          *wilder-option-interval*
             Interval of the |timer| used to check whether the cmdline has
             changed, in milliseconds.
             Only applicable if |wilder-option-use_cmdlinechanged| is false.
 
             Default: 100
 
-before_cursor                       *wilder-option-before_cursor*
+`before_cursor`                     *wilder-option-before_cursor*
             If true, wilder will look only at the part of the cmdline before
             the cursor, and when selecting a completion, the entire cmdline
             will be replaced.
@@ -87,14 +88,14 @@ before_cursor                       *wilder-option-before_cursor*
 
             Default: 0
 
-num_workers                         *wilder-option-num_workers*
+`num_workers`                       *wilder-option-num_workers*
             Number of workers for the Python 3 |remote-plugin|.
             Has to be set at startup, before wilder is first run. Setting the
             option after the first run has no effect.
 
             Default: 2
 
-pipeline                            *wilder-option-pipeline*
+`pipeline`                          *wilder-option-pipeline*
             Sets the pipeline to use to get completions.
             See |wilder-pipeline|.
 
@@ -104,14 +105,14 @@ pipeline                            *wilder-option-pipeline*
                      |wilder#python_search_pipeline()| for Neovim with
                                                        Python 3 support
 
-renderer                            *wilder-option-renderer*
+`renderer`                          *wilder-option-renderer*
             Sets the renderer to used to display the completions.
             See |wilder-renderer|.
 
             Default: |wilder#wildmenu_renderer()| with
                      |wilder#previous_arrow()| and |wilder#next_arrow()|
 
-pre_hook                            *wilder-option-pre_hook*
+`pre_hook`                          *wilder-option-pre_hook*
             A function which takes a {ctx}. This function is called when
             wilder starts, or when wilder becomes unhidden. See
             |wilder-hidden|.
@@ -120,7 +121,7 @@ pre_hook                            *wilder-option-pre_hook*
 
             Default: None
 
-post_hook                           *wilder-option-post_hook*
+`post_hook`                         *wilder-option-post_hook*
             A function which takes a {ctx}. This function is called when
             wilder stops, or when wilder becomes hidden. See
             |wilder-hidden|.
@@ -148,8 +149,8 @@ result of the last element will be the completions for that query. See
 A contrived example:
 >
     wilder#set_option('pipeline', [
-      \   {ctx, x -> [x, 'foo', 'bar']},
-      \   ])
+      \ {ctx, x -> [x, 'foo', 'bar']},
+      \ ])
 <
 This will return the 3 completions, the current cmdline and the strings 'foo'
 and 'bar'.
@@ -203,9 +204,9 @@ a pipeline based on certain conditions.
 Example:
 >
     wilder#set_option('pipeline', [
-      \   {ctx, x -> empty(x) ? v:false : x},
-      \   {ctx, x -> MyCompletionFunction(x)},
-      \   ]
+      \ {ctx, x -> empty(x) ? v:false : x},
+      \ {ctx, x -> MyCompletionFunction(x)},
+      \ ]
 <
 This pipeline will terminate early if the cmdline is empty.
 Since this is a common pattern, it is provided as the |wilder#check()|
@@ -243,10 +244,10 @@ than one will result in an error.
 
 Example:
 >
-    wilder#set_option('pipeline', [
-      \   {_, x -> {ctx -> timer_start(100, {-> wilder#resolve(ctx, x)})}},
-      \   {ctx, x -> MyCompletionFunction(x)},
-      \   ]
+    call wilder#set_option('pipeline', [
+      \ {_, x -> {ctx -> timer_start(100, {-> wilder#resolve(ctx, x)})}},
+      \ {ctx, x -> MyCompletionFunction(x)},
+      \ ]
 <
 This will call `MyCompletionFunction` after a 100 millisecond delay.
 
@@ -355,14 +356,32 @@ The Result dictionary has the following keys:
 6. Finally, the output from above will be inserted to the cmdline.
    See |wilder-option-before_cursor| on which part of the cmdline will be
    replaced.
-   If {result} does not contain the key `output`, its {x} entry is used.
-   Otherwise, |wilder-pipeline-result-output| is applied. The result is then
+   If {result} does not contain the key `replace`, its {x} entry is used.
+   Otherwise, |wilder-pipeline-result-replace| is applied. The result is then
    used to replace the cmdline.
 
 The |wilder#result()| pipe is a helper which allows easy modification of the
 result dictionary.
 
                                     *wilder-pipeline-pipe*
+A |wilder-pipeline| is a list of pipes that transforms the initial input into
+the final result. For example:
+
+>
+    call wilder#set_option('pipeline', [
+      \ wilder#check({-> getcmdtype() ==# '/' || getcmdtype() ==# '?'}),
+      \ wilder#vim_substring_pattern(),
+      \ wilder#vim_search(),
+      \ ])
+<
+
+This pipeline checks that the user is currently searching with '/' or '?',
+transforms the current cmdline to a substring pattern and searches the current
+buffer for matching candidates using the pattern from before.
+
+See |wilder-pipeline| for more details.
+
+Here is the list of provided pipes:
 
 wilder#check({f}, ...)              *wilder#check()*
                                     Pipe~
@@ -401,14 +420,14 @@ wilder#branch({list_of_pipelines})  *wilder#branch()*
             Example:
 >
                 wilder#set_option('pipeline', [
-                  \   wilder#branch(
-                  \     [
-                  \       wilder#check({ctx, x -> empty(x)}),
-                  \       wilder#history(),
-                  \     ],
-                  \     wilder#search_pipeline(),
-                  \   ),
-                  \   ]
+                  \ wilder#branch(
+                  \   [
+                  \     wilder#check({ctx, x -> empty(x)}),
+                  \     wilder#history(),
+                  \   ],
+                  \   wilder#search_pipeline(),
+                  \ ),
+                  \ ]
 <
             This pipeline will return completions from the history is {x} is
             empty.
@@ -566,8 +585,8 @@ wilder#result([{dictionary}])       *wilder#result()*
             [
             \ {ctx, x -> MyCompletionFunction(x)},
             \ wilder#result({'draw': [{ctx, x -> (ctx['i'] + 1) . '. ' . x}]}),
-            \ wilder#result({'draw': [{ctx, x -> ctx['selected']
-            \                         ? '[' . x . ']' : x)}]}),
+            \ wilder#result({'draw': [{ctx, x -> ctx['selected'] ?
+            \                         '[' . x . ']' : x)}]}),
             \ ]
 <
             This pipeline will first prepend the index of the candidate and
@@ -2564,7 +2583,7 @@ Minimal Configuration~
     cmap <expr> <Tab> wilder#in_context() ? wilder#next() : "\<Tab>"
     cmap <expr> <S-Tab> wilder#in_context() ? wilder#previous() : "\<S-Tab>"
 
-    " only / and ? is enabled by default
+    " only / and ? are enabled by default
     call wilder#set_option('modes', ['/', '?', ':'])
 <
 
@@ -2577,7 +2596,10 @@ Pipelines (Neovim only)~
           \       wilder#check({_, x -> empty(x)}),
           \       wilder#history(100),
           \     ],
-          \     wilder#cmdline_pipeline(),
+          \     wilder#cmdline_pipeline({
+          \       'fuzzy': 1,
+          \       'use_python': 1,
+          \     }),
           \     wilder#python_search_pipeline({
           \       'fuzzy': 1,
           \     }),
@@ -2585,12 +2607,12 @@ Pipelines (Neovim only)~
           \ ])
 <
 
-Airline/Lightline Theme Renderer~
+Airline/Lightline Theme for Wildmenu Renderer~
 >
     " use wilder#lightline_theme() for Lightline
     call wilder#set_option('renderer', wilder#wildmenu_renderer(
           \ wilder#airline_theme({
-          \   'apply_highlights': wilder#query_common_subsequence_spans(),
+          \   'highlighter': wilder#basic_highlighter(),
           \   'separator': ' · ',
           \ })))
 <

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1130,15 +1130,15 @@ wilder#wildmenu_renderer([{options}])
 
             {data} is the dictionary from |wilder-pipeline-result-data|.
 
-            |wilder#query_highlighter()| and |wilder#pcre2_highlighter()| are
-            helper functions which can be used to apply accents to the
-            candidates from |wilder#cmdline_pipeline()| and
-            |wilder#python_search_pipeline()|.
+            |wilder#basic_highlighter()| is the highlighter which can be used
+            out of the box, but is slow. For best performance, use
+            |wilder#lua_fzy_highlighter()|. The Python highlighters are slow
+            in general due to RPC overhead.
 
             Example:
 >
             call wilder#set_option('renderer', wilder#wildmenu_renderer({
-                  \ 'highlighter': wilder#pcre2_highlighter(),
+                  \ 'highlighter': wilder#basic_highlighter(),
                   \ }))
 <
 
@@ -1542,10 +1542,10 @@ wilder#popupmenu_renderer([{options}])
 
             Default: [' ', wilder#popupmenu_scrollbar()]
 
-            `apply_highlights`
+            `highlighter`
             Optional~
 
-            See the `apply_highlights` key of |wilder#wildmenu_renderer()|.
+            See the `highlighter` key of |wilder#wildmenu_renderer()|.
 
             Default: []
 
@@ -2165,7 +2165,7 @@ wilder#python_fuzzywuzzy_sorter([{partial}])
             The {partial} argument is passed to
             |wilder#python_fuzzywuzzy_sort()| as an option.
 
-wilder#query_highlighter([{opts}])  *wilder#query_highlighter()*
+wilder#basic_highlighter([{opts}])  *wilder#basic_highlighter()*
                                     python option only for Neovim~
             Helper function which returns a function for the
             `highlighter` option for |wilder#wildmenu_renderer()| or
@@ -2230,13 +2230,10 @@ wilder#pcre2_highlighter([{opts}])  *wilder#pcre2_highlighter()*
 
             Default: 're'
 
-            Note: This function is slow and should be avoided by users who are
-            concerned about performance. Using 'lua' is slightly faster, but
-            will still increase the rendering time.
-
 wilder#cpsm_highlighter([{opts}])   *wilder#cpsm_highlighter()*
+                                    *wilder#python_cpsm_highlighter()*
+wilder#python_cpsm_highlighter([{opts}])
                                     Neovim only~
-                                    Async~
                                     cpsm plugin required~
             Helper function which returns a function for the `highlighter`
             option for |wilder#wildmenu_renderer()| or
@@ -2262,8 +2259,23 @@ wilder#cpsm_highlighter([{opts}])   *wilder#cpsm_highlighter()*
 
             Default: 'basic'
 
-            Note: This function is slow and should be avoided by users who are
-            concerned about performance.
+wilder#lua_fzy_highlighter()        *wilder#lua_fzy_highlighter()*
+                                    Neovim only~
+                                    fzy-lua-native plugin required~
+            Helper function which returns a function for the `highlighter`
+            option for |wilder#wildmenu_renderer()| or
+            |wilder#popupmenu_renderer()|.
+
+            Returns a function which takes {ctx}, {candidate} and {data} as
+            arguments.
+            If {data} does not contain the key `query`, returns 0.
+            Otherwise, returns a list of highlight spans as determined by
+            `fzy-lua-native`.
+
+            The `fzy-lua-native` plugin can be found at
+            https://github.com/romgrk/fzy-lua-native.
+
+            Note: This may not handle multibyte characters properly.
 
                                     *wilder#project_root()*
 wilder#project_root([{root_markers}])
@@ -2358,10 +2370,14 @@ wilder#python_sort_fuzzywuzzy({ctx}, {opts}, {candidates}, {query})
                                     Deprecated~
             Deprecated: Use |wilder#python_fuzzywuzzy_sort()|.
 
+wilder#query_highlighter([{opts}])  *wilder#query_highlighter()*
+                                    Deprecated~
+            Deprecated: Use |wilder#basic_highlighter()|.
+
                                     *wilder#query_common_subsequence_spans()*
 wilder#query_common_subsequence_spans([{opts}])
                                     Deprecated~
-            Deprecated: Use |wilder#query_highlighter()|.
+            Deprecated: Use |wilder#basic_highlighter()|.
 
                                     *wilder#pcre2_capture_spans()*
 wilder#pcre2_capture_spans([{opts}])

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1728,7 +1728,17 @@ wilder#popupmenu_devicons([{options}])
             Adds devicons for files and buffers.
 
             {options} is a dictionary with keys:
+            `get_icon`
+            Optional~
+            A function name or a function. The function should take 2
+            arguments {file_name} and {is_dir} and return the icon to use.
+
+            To use `nerdfont.vim`, set this to {name -> nerdfont#find(name)}.
+
+            Default: 'WebDevIconsGetFileTypeSymbol'
+
             `padding`
+            Optional~
             A list in the form of [{left_padding_width},
             {right_padding_width}].
 

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1707,6 +1707,18 @@ wilder#popupmenu_spinner([{options}])
 
             Default: 100
 
+                                    *wilder#popupmenu_devicons()*
+wilder#popupmenu_devicons([{options}])
+                                    wilder#popupmenu_renderer() column~
+            Adds devicons for files and buffers.
+
+            {options} is a dictionary with keys:
+            `padding`
+            A list in the form of [{left_padding_width},
+            {right_padding_width}].
+
+            Default: [0, 1]
+
                                     *wilder#popupmenu_buffer_status()*
 wilder#popupmenu_buffer_status([{options}])
                                     wilder#popupmenu_renderer() column~

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1357,8 +1357,8 @@ The following items are provided:
                                     *wilder#wildmenu_previous_arrow()*
 wilder#wildmenu_previous_arrow([{options}])
                                     wilder#wildmenu_renderer() item~
-            Returns an item which shows a previous arrow when there are
-            previous candidates which do not fit in the current view.
+            Adds an arrow when there are candidates to the left which do not
+            fit in the current view.
             Note Has to be used with |wilder#next_arrow()|, otherwise the
             `len` entry will not be evaluated correctly.
 
@@ -1378,8 +1378,8 @@ wilder#wildmenu_previous_arrow([{options}])
                                     *wilder#wildmenu_next_arrow()*
 wilder#wldmnue_next_arrow([{options}])
                                     wilder#wildmenu_renderer() item~
-            Returns an item which shows a next arrow when there are
-            additional candidates which do not fit in the current view.
+            Adds an arrow when there are additional candidates to the right
+            which do not fit in the current view.
             Note Has to be used with |wilder#previous_arrow()|, otherwise the
             `len` entry will not be evaluated correctly.
 
@@ -1404,8 +1404,8 @@ wilder#wldmnue_next_arrow([{options}])
              
 wilder#wildmenu_index([{options}])  *wilder#wildmenu_index()*
                                     wilder#wildmenu_renderer() item~
-            Returns an item which shows the index of the currently
-            selected candidate and the total number of candidates.
+            Adds the index of the currently selected candidate and the total
+            number of candidates.
             For example, if there are 10 candidates and the 5th one is
             selected, it will draw ' 5/10'.
 
@@ -1419,8 +1419,8 @@ wilder#wildmenu_index([{options}])  *wilder#wildmenu_index()*
                                     *wilder#wildmenu_spinner()*
 wilder#wildmenu_spinner([{options}])
                                     wilder#wildmenu_renderer() item~
-            Returns an item which indicates whether the current pipeline
-            is still running.
+            Adds a spinner which indicates whether the current pipeline is
+            still running.
 
             {options} is a dictionary with keys:
             `frames`
@@ -1452,22 +1452,21 @@ wilder#wildmenu_spinner([{options}])
             Default: 100
 
                                     *wilder#wildmenu_powerline_separator()*
-wilder#wildmenu_powerline_separator({str}, {fg}, {bg}, [{key}])
+wilder#wildmenu_powerline_separator({str}, {fg}, {bg}, [{name}])
                                     wilder#wildmenu_renderer() item~
-            Helper function to draw an powerline-like separator.
-            {str} should be the separator character
+            Draws a powerline-like separator.
+            {str} should be the separator character.
             {fg} is the highlight group from which the |highlight-ctermfg| and
-            |highlight-guifg| should be from.
+            |highlight-guifg| is derived from.
             {bg} is the highlight group from which the |highlight-ctermbg| and
-            |highlight-guibg| should be from.
-            {key} is an optional argument which will be used to name the new
+            |highlight-guibg| is derived from.
+            {name} is an optional argument which will be used to name the new
             highlight group. Otherwise, a new name will be generated.
 
                                     *wilder#wildmenu_condition()*
 wilder#wildmenu_condition({predicate}, {if_true}, [{if_false}])
                                     wilder#wildmenu_renderer() item~
-            Returns a item which renders the given items based on the
-            {predicate}.
+            Draws the given items based on the {predicate}.
             {predicate} is a function which takes a {ctx} and the pipeline
             result {result} and returns true or false.
             The keys of {ctx} are the same as the ones in the `render` key of
@@ -1646,7 +1645,7 @@ For |wilder#popupmenu_renderer()|, columns can be of the following types:
                                     *wilder#popupmenu_scrollbar()*
 wilder#popupmenu_scrollbar([{options}]
                                     wilder#popupmenu_renderer() column~
-            Returns a column which adds a scrollbar to the popupmenu.
+            Adds a scrollbar to the popupmenu.
 
             {options} is a dictionary with keys:
             `thumb_char`
@@ -1676,8 +1675,8 @@ wilder#popupmenu_scrollbar([{options}]
                                     *wilder#popupmenu_spinner()*
 wilder#popupmenu_spinner([{options}])
                                     wilder#popupmenu_renderer() column~
-            Returns a column which indicates whether the current pipeline is
-            still running.
+            Adds a spinner to indicate whether the current pipeline is still
+            running.
 
             {options} is a dictionary with keys:
             `frames`
@@ -1707,6 +1706,42 @@ wilder#popupmenu_spinner([{options}])
             The time in milliseconds for each frame.
 
             Default: 100
+
+                                    *wilder#popupmenu_buffer_status()*
+wilder#popupmenu_buffer_status([{options}])
+                                    wilder#popupmenu_renderer() column~
+            Adds buffer status information.
+
+            {options} is a dictionary with keys:
+            `flags`
+            Optional~
+            The flags to show.
+
+            Each character represents a flag to draw. The characters can be:
+              `<Space>`
+              Empty space for padding.
+
+              `1`
+              Shows the buffer number |bufnr()|.
+
+              `%`
+              Shows '%' if the buffer is the |current-buffer|, '#' if the buffer
+              is the |alternate-file| and ' ' otherwise.
+
+              `+`
+              Shows '+' if the buffer has been 'modified' and ' ' otherwise.
+
+              `-`
+              Shows '-' if the buffer is not 'modifiable', '=' if the buffer is
+              'readonly' and ' ' otherwise.
+
+              Default: '1 % + '
+
+            `hl`
+            The highlight group to use.
+
+            `selected_hl`
+            The highlight group to use when the line is selected.
 
 
 ==============================================================================

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1130,10 +1130,10 @@ wilder#wildmenu_renderer([{options}])
 
             {data} is the dictionary from |wilder-pipeline-result-data|.
 
-            |wilder#basic_highlighter()| is the highlighter which can be used
-            out of the box, but is slow. For best performance, use
-            |wilder#lua_fzy_highlighter()|. The Python highlighters are slow
-            in general due to RPC overhead.
+            Note: Highlighting is slow and will result in noticeable input
+            delay. For best performance, use the Lua highlighters e.g.
+            |wilder#lua_fzy_highlighter()|. Python highlighters have high RPC
+            overhead and should be avoided.
 
             Example:
 >
@@ -2288,18 +2288,42 @@ wilder#project_root([{root_markers}])
 
 wilder#renderer_mux({args})         *wilder#renderer_mux()*
             Creates a renderer multiplexer which chooses the renderer to use
-            based on |getcmdchar()|.
+            based on {args}.
 
-            The keys of {args} should be a cmdtype e.g. '/', ':' or '?'.
+            {args} can either be a Dictionary or a List.
 
-            If the '?' key is omitted and the '/' key is present, '?' will use
-            the renderer for '/'.
+            If {args} is a Dictionary, it should be in the form {{key}:
+            {rendderer}} where the keys represent a cmdtype e.g. '/', ':' or
+            '?'. The renderer with key equal to |getcmdtype()| will be the
+            used.
+
+            '/' matches both '/' and '?'.
 
             The special key 'substitute' sets the renderer when the cmdline is
-            in a |:substitute| command. If omitted, the '/' renderer is used.
+            in a |:substitute| command. If omitted, the ':' renderer is used.
+
+            If {args} is a List, it should be a list of [{check}, {renderer}]
+            elements. {check} can either be a function or string. The list is
+            iterated in order and the {renderer} with the first passing
+            {check} is used.
+
+            If {check} is a function, it should take an empty {ctx} and return
+            true if {renderer} should be used.
+
+            If {check} is a string, the |getcmdtype()| described in the
+            Dictionary section above is used.
+
+            {renderer} can be 0 indicating no renderer is used.
 
             Example:
 >
+            " disables rendering in subsitute commands
+            wilder#set_option('renderer, wilder#renderer_mux([
+                  \ ['substitute', 0],
+                  \ [':', wilder#popupmenu_renderer()],
+                  \ ['/', wilder#wildmenu_renderer()],
+                  \ ])
+
             wilder#set_option('renderer, wilder#renderer_mux({
                   \ ':': wilder#popupmenu_renderer(),
                   \ '/': wilder#wildmenu_renderer(),

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -460,6 +460,9 @@ wilder#python_fuzzy_pattern([{options}])
             If true, the regex will only match at the beginning of a word
             boundary.
 
+            Note: This makes the regex more complicated and will slow down the
+            fuzzy searching.
+
             Default: 1
 
                                     *wilder#python_fuzzy_delimiter_pattern()*
@@ -495,6 +498,9 @@ wilder#python_fuzzy_delimiter_pattern([{options}])
             Optional~
             If true, the regex will only match at the beginning of a word
             boundary or delimiter.
+
+            Note: This makes the regex more complicated and will slow down the
+            fuzzy searching.
 
             Default: 1
 

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1796,13 +1796,22 @@ wilder#popupmenu_buffer_flags([{options}])
               `+`
               Shows '+' if the buffer has been 'modified' and ' ' otherwise.
 
-              Default: '1 %a-+ '
+              `u`
+              Shows ' ' if the buffer is 'buflisted' and 'u' otherwise.
+
+            Default: '1u%a-+ '
 
             `hl`
+            Optional~
             The highlight group to use.
 
+            Default: The `default` highlight of the renderer
+
             `selected_hl`
+            Optional~
             The highlight group to use when the line is selected.
+
+            Default: The `selected` highlight of the renderer
 
 
 ==============================================================================

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -2285,6 +2285,13 @@ wilder#basic_highlighter([{opts}])  *wilder#basic_highlighter()*
 
             Default: 0
 
+                                    *wilder#vim_basic_highlighter()*
+wilder#vim_basic_highlighter([{opts}])
+                                    *wilder#python_basic_highlighter()*
+wilder#python_basic_highlighter([{opts}])
+            Shorthand for |wilder#basic_highlighter()| with the `language`
+            option set to `vim` and `python` respectively.
+
 wilder#pcre2_highlighter([{opts}])  *wilder#pcre2_highlighter()*
                                     Neovim only~
                                     pcre2 package required for lua option~
@@ -2319,6 +2326,13 @@ wilder#pcre2_highlighter([{opts}])  *wilder#pcre2_highlighter()*
             The regex engine to use. Only used when `language` is 'python'.
 
             Default: 're'
+
+                                    *wilder#python_pcre2_highlighter()*
+wilder#python_pcre2_highlighter([{opts}])
+                                    *wilder#lua_pcre2_highlighter()*
+wilder#lua_pcre2_highlighter([{opts}])
+            Shorthand for |wilder#pcre2_highlighter()| with the `language`
+            option set to `python` and `lua` respectively.
 
 wilder#cpsm_highlighter([{opts}])   *wilder#cpsm_highlighter()*
                                     *wilder#python_cpsm_highlighter()*

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1754,6 +1754,9 @@ wilder#popupmenu_devicons([{options}])
 
             To use `nerdfont.vim`, set this to {name -> nerdfont#find(name)}.
 
+            Note: The icons returned should all be of the same
+            |strdisplaywidth()|.
+
             Default: 'WebDevIconsGetFileTypeSymbol'
 
             `padding`

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -494,7 +494,7 @@ wilder#python_fuzzy_delimiter_pattern([{options}])
             `start_at_boundary`
             Optional~
             If true, the regex will only match at the beginning of a word
-            boundary.
+            boundary or delimiter.
 
             Default: 1
 

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1606,16 +1606,15 @@ For |wilder#popupmenu_renderer()|, columns can be of the following types:
             states.
 
             Function:
-            A function which takes a {ctx}, the pipeline result {result} and
-            the index of the current row {i} and returns a string or a list of
-            highlight chunks. See the List section above for the structure of
-            highlight chunks.
+            A function which takes a {ctx} and the pipeline result {result}
+            and returns a string or a list of highlight chunks. See the List
+            section above for the structure of highlight chunks.
 
             The keys of {ctx} are the same as the ones in the `render`
             key of |wilder-renderer|, with an additional `page` key which is a
             2 element array [{start}, {end}] indicating the start and end of
-            the candidates currently being drawn. If no candidates are drawn,
-            the page is [-1, -1].
+            the candidates currently being drawn. It can be assumed that if
+            this function is called, there is at least 1 candidate.
 
             Dictionary:
             A dictionary with the following keys:

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1766,14 +1766,18 @@ wilder#popupmenu_buffer_flags([{options}])
               Shows '%' if the buffer is the |current-file|, '#' if the buffer
               is the |alternate-file| and ' ' otherwise.
 
-              `+`
-              Shows '+' if the buffer has been 'modified' and ' ' otherwise.
+              `a`
+              Shows 'a' if the buffer is an |active-buffer|, 'h' if the buffer
+              is a |hidden-buffer| and ' ' otherwise (|inactive-buffer|).
 
               `-`
               Shows '-' if the buffer is not 'modifiable', '=' if the buffer is
               'readonly' and ' ' otherwise.
 
-              Default: '1 % + '
+              `+`
+              Shows '+' if the buffer has been 'modified' and ' ' otherwise.
+
+              Default: '1 %a-+ '
 
             `hl`
             The highlight group to use.

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -186,6 +186,11 @@ The first argument to a pipe is a {ctx} context object. The context is a
                 `run_id`
                 A number to indicate the current pipeline running.
 
+                `session_id`
+                A number to indicate the current cmdline session. A session
+                begins when the cmdline is ended and ends when leaving the
+                cmdline.
+
 Although it is not recommended, pipes can use the {ctx} to pass information to
 subsequent pipes.
 
@@ -993,6 +998,10 @@ A renderer is a dictionary containing the following keys:
 
                 `run_id`
                 The `run_id` from the context which returned {result}. See
+                |wilder-pipeline-context|.
+
+                `session_id`
+                The `session_id` from the context which returned {result}. See
                 |wilder-pipeline-context|.
 
             `pre_hook`

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1752,7 +1752,8 @@ wilder#popupmenu_buffer_flags([{options}])
             {options} is a dictionary with keys:
             `flags`
             Optional~
-            The flags to show.
+            A string representing the flags to show. The flags are drawn in
+            the order specified in the string.
 
             Each character represents a flag to draw. The characters can be:
               `<Space>`
@@ -1762,7 +1763,7 @@ wilder#popupmenu_buffer_flags([{options}])
               Shows the buffer number |bufnr()|.
 
               `%`
-              Shows '%' if the buffer is the |current-buffer|, '#' if the buffer
+              Shows '%' if the buffer is the |current-file|, '#' if the buffer
               is the |alternate-file| and ' ' otherwise.
 
               `+`
@@ -2333,6 +2334,9 @@ wilder#python_cpsm_highlighter([{opts}])
             If {data} does not contain the key `query`, returns 0.
             Otherwise, returns a list of highlight spans as determined by
             `cpsm`.
+
+            The `cpsm` plugin can be found at
+            https://github.com/nixprime/cpsm.
 
             {opts} is a dictionary with keys:
             `cpsm_path`

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1596,10 +1596,20 @@ For |wilder#popupmenu_renderer()|, columns can be of the following types:
             The empty string ' ' can be used to give padding to the left or
             right of the popupmenu.
 
+            List:
+            A list of highlight chunks.
+
+            A highlight chunk can be in the form of [{text}], [{text}, {hl}]
+            or [{text}, {default_hl}, {selected_hl}]. For [{text}], the
+            default and selected highlights of the renderer will be used. For
+            [{text}, {hl}], {hl} will be used for both default and selected
+            states.
+
             Function:
             A function which takes a {ctx}, the pipeline result {result} and
             the index of the current row {i} and returns a string or a list of
-            highlight chunks [[{text}, {hl}], ...].
+            highlight chunks. See the List section above for the structure of
+            highlight chunks.
 
             The keys of {ctx} are the same as the ones in the `render`
             key of |wilder-renderer|, with an additional `page` key which is a

--- a/lua/wilder.lua
+++ b/lua/wilder.lua
@@ -1,33 +1,67 @@
-local pcre2 = require 'pcre2'
-
 local cached_pattern = nil
 local cached_re = nil
 
-local function highlight_pcre2(pattern, str)
-	local re
-	if pattern == cached_pattern then
-		re = cached_re
-	else
-		re = assert(pcre2.new(pattern, pcre2.UCP, pcre2.UTF))
-		re:jit_compile()
-	end
+local function pcre2_highlight(pattern, str)
+  local pcre2 = require('pcre2')
 
-	local head, tail, err = re:match(str)
-	if err or not head then
-		return {}
-	end
+  local re
+  if pattern == cached_pattern then
+    re = cached_re
+  else
+    re = assert(pcre2.new(pattern, pcre2.UCP, pcre2.UTF))
+    re:jit_compile()
+  end
 
-	local captures = {}
+  local head, tail, err = re:match(str)
+  if err or not head then
+    return {}
+  end
 
-	for i = 1, #head do
-		if tail[i] > 0 then
-			table.insert(captures, {head[i], tail[i]})
-		end
-	end
+  local captures = {}
 
-	return captures
+  -- remove first element which is the matched string
+  for i = 2, #head do
+    if tail[i] > 0 then
+      -- convert from [{start+1}, {end+1}] to [{start}, {len}]
+      table.insert(captures, {head[i] - 1, tail[i] - head[i] + 1})
+    end
+  end
+
+  return captures
+end
+
+local function fzy_highlight(needle, haystack)
+  local fzy = require('fzy-lua-native')
+
+  local positions = fzy.positions(needle, haystack)
+
+  if #positions == 0 then
+    return {}
+  end
+
+  local spans = {}
+  local start = positions[1] - 1
+  local finish = positions[1] - 1
+
+  -- consecutive sequences may represent multibyte characters so
+  -- we merge them together
+  for i = 2, #positions do
+    local current = positions[i] - 1
+
+    if current ~= finish + 1 then
+      table.insert(spans, {start, finish - start + 1})
+      start = current
+    end
+
+    finish = current
+  end
+
+  table.insert(spans, {start, finish - start + 1})
+
+  return spans
 end
 
 return {
-	highlight_pcre2 = highlight_pcre2,
+  fzy_highlight = fzy_highlight,
+  pcre2_highlight = pcre2_highlight,
 }

--- a/rplugin/python3/wilder/__init__.py
+++ b/rplugin/python3/wilder/__init__.py
@@ -726,8 +726,8 @@ class Wilder(object):
 
         return [x[0] for x in sorted(xs, key=lambda x: x[1])]
 
-    @neovim.function('_wilder_python_highlight_query', sync=True)
-    def _highlight_query(self, args):
+    @neovim.function('_wilder_python_basic_highlight', sync=True)
+    def _basic_highlight(self, args):
         string = args[0]
         query = args[1]
         case_sensitive = args[2]
@@ -764,7 +764,7 @@ class Wilder(object):
 
         return spans
 
-    @neovim.function('_wilder_python_highlight_pcre2', sync=True)
+    @neovim.function('_wilder_python_pcre2_highlight', sync=True)
     def _highlight_pcre2(self, args):
         pattern = args[0]
         string = args[1]
@@ -789,7 +789,7 @@ class Wilder(object):
 
         return captures
 
-    @neovim.function('_wilder_python_highlight_cpsm', sync=True)
+    @neovim.function('_wilder_python_cpsm_highlight', sync=True)
     def _highlight_cpsm(self, args):
         opts = args[0]
         x = args[1]

--- a/rplugin/python3/wilder/__init__.py
+++ b/rplugin/python3/wilder/__init__.py
@@ -755,7 +755,7 @@ class Wilder(object):
         return spans
 
     @neovim.function('_wilder_python_pcre2_highlight', sync=True)
-    def _highlight_pcre2(self, args):
+    def _pcre2_highlight(self, args):
         pattern = args[0]
         string = args[1]
         module_name = args[2]
@@ -780,7 +780,7 @@ class Wilder(object):
         return captures
 
     @neovim.function('_wilder_python_cpsm_highlight', sync=True)
-    def _highlight_cpsm(self, args):
+    def _cpsm_highlight(self, args):
         opts = args[0]
         x = args[1]
         query = args[2]

--- a/rplugin/python3/wilder/__init__.py
+++ b/rplugin/python3/wilder/__init__.py
@@ -12,7 +12,6 @@ import itertools
 import os
 from pathlib import Path
 import pwd
-import queue
 import re
 import shutil
 import stat
@@ -32,7 +31,6 @@ class Wilder(object):
     def __init__(self, nvim):
         self.nvim = nvim
         self.has_init = False
-        self.queue = queue.Queue()
         self.events = []
         self.events_lock = threading.Lock()
         self.executor = None
@@ -43,8 +41,17 @@ class Wilder(object):
         self.path_files_dict = dict()
         self.added_sys_path = set()
 
-    def handle(self, ctx, x, command='resolve'):
-        self.nvim.call('wilder#' + command, ctx, x)
+    def resolve(self, ctx, x):
+        self.nvim.async_call(self._resolve, ctx, x)
+
+    def _resolve(self, ctx, x):
+        self.nvim.call('wilder#resolve', ctx, x)
+
+    def reject(self, ctx, x):
+        self.nvim.async_call(self._reject, ctx, x)
+
+    def _reject(self, ctx, x):
+        self.nvim.call('wilder#reject', ctx, x)
 
     def echomsg(self, x):
         self.nvim.session.threadsafe_call(lambda: self.nvim.command('echomsg "' + x + '"'))
@@ -71,21 +78,6 @@ class Wilder(object):
 
         return self.executor.submit(functools.partial( fn, *([event] + args), ))
 
-    def consumer(self):
-        while True:
-            args = self.queue.get()
-            ctx = args[0]
-            res = args[1]
-
-            if ctx['run_id'] < self.run_id:
-                continue
-
-            if len(args) > 2:
-                command = args[2]
-                self.nvim.async_call(self.handle, ctx, res, command=command)
-            else:
-                self.nvim.async_call(self.handle, ctx, res)
-
     @neovim.function('_wilder_init', sync=True)
     def _init(self, args):
         if self.has_init:
@@ -96,8 +88,6 @@ class Wilder(object):
         opts = args[0]
 
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=opts['num_workers'])
-        t = threading.Thread(target=self.consumer, daemon=True)
-        t.start()
 
     def add_sys_path(self, path):
         path = os.path.expanduser(path)
@@ -157,17 +147,17 @@ class Wilder(object):
                     return
 
             if 'timeout' in result:
-                self.queue.put((ctx, False,))
+                self.resolve(ctx, False)
                 return
 
             if 'error' in result:
-                self.queue.put((ctx, 'find_files: ' + result['error'], 'reject',))
+                self.reject(ctx, 'find_files: ' + result['error'])
                 return
 
             candidates = result['files']
 
             if not candidates:
-                return self.queue.put((ctx, [],))
+                return self.resolve(ctx, [])
 
             if query:
                 for filter in filters:
@@ -209,9 +199,9 @@ class Wilder(object):
             if find_dir:
                 candidates = [c + os.sep if c and c[-1] != os.sep else c  for c in candidates]
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_file_finder: ' + str(e), 'reject'))
+            self.reject(ctx, 'python_file_finder: ' + str(e))
 
     def find_files_subprocess(self, command, path, timeout_ms, result):
         try:
@@ -252,7 +242,7 @@ class Wilder(object):
             return
 
         time.sleep(t)
-        self.queue.put((ctx, x,))
+        self.resolve(ctx, x)
 
     @neovim.function('_wilder_python_search', sync=False, allow_nested=True)
     def _search(self, args):
@@ -275,9 +265,9 @@ class Wilder(object):
             if event.is_set():
                 return
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_search: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_search: ' + str(e))
 
     def search(self, event, opts, x, buf):
         module_name = opts['engine'] if 'engine' in opts else 're'
@@ -314,9 +304,9 @@ class Wilder(object):
 
         try:
             res = [x for x in candidates if not (x in seen or seen.add(x))]
-            self.queue.put((ctx, res,))
+            self.resolve(ctx, res)
         except Exception as e:
-            self.queue.put((ctx, 'python_uniq_filt: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_uniq_filt: ' + str(e))
 
     @neovim.function('_wilder_python_lexical_sort', sync=False, allow_nested=True)
     def _sort(self, args):
@@ -329,9 +319,9 @@ class Wilder(object):
         try:
             res = sorted(candidates)
 
-            self.queue.put((ctx, res,))
+            self.resolve(ctx, res)
         except Exception as e:
-            self.queue.put((ctx, 'python_lexical_sort: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_lexical_sort: ' + str(e))
 
     # sync=True as it needs to query nvim for some data
     @neovim.function('_wilder_python_get_file_completion', sync=True, allow_nested=True)
@@ -477,9 +467,9 @@ class Wilder(object):
             elif expand_arg == '..':
                 res.insert(0, '../')
 
-            self.queue.put((ctx, res,))
+            self.resolve(ctx, res)
         except Exception as e:
-            self.queue.put((ctx, 'python_get_file_completion: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_get_file_completion: ' + str(e))
 
     # Returns True if p2 is a descendant of p1
     def is_descendant_path(self, p1, p2):
@@ -506,9 +496,9 @@ class Wilder(object):
                     res.append(user.pw_name)
 
             res = sorted(res)
-            self.queue.put((ctx, res,))
+            self.resolve(ctx, res)
         except Exception as e:
-            self.queue.put((ctx, 'python_get_users: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_get_users: ' + str(e))
 
     @neovim.function('_wilder_python_fuzzy_filt', sync=False, allow_nested=True)
     def _fuzzy_filt(self, args):
@@ -521,9 +511,9 @@ class Wilder(object):
             if event.is_set():
                 return
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_fuzzy_filt: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_fuzzy_filt: ' + str(e))
 
     # case_sensitive: 0 - case insensitive
     #                 1 - case sensitive
@@ -590,9 +580,9 @@ class Wilder(object):
             if event.is_set():
                 return
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_fruzzy_filt: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_fruzzy_filt: ' + str(e))
 
     def fruzzy_filt(self, *args):
         opts = args[1]
@@ -646,9 +636,9 @@ class Wilder(object):
             if event.is_set():
                 return
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_cpsm_filt: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_cpsm_filt: ' + str(e))
 
     def cpsm_filt(self, event, opts, candidates, query):
         if 'cpsm_path' in opts:
@@ -673,9 +663,9 @@ class Wilder(object):
             if event.is_set():
                 return
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_difflib_sort: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_difflib_sort: ' + str(e))
 
     def difflib_sort(self, event, opts, candidates, query):
         quick = opts['quick'] if 'quick' in opts else True
@@ -707,9 +697,9 @@ class Wilder(object):
             if event.is_set():
                 return
 
-            self.queue.put((ctx, candidates,))
+            self.resolve(ctx, candidates)
         except Exception as e:
-            self.queue.put((ctx, 'python_fuzzywuzzy_sort: ' + str(e), 'reject',))
+            self.reject(ctx, 'python_fuzzywuzzy_sort: ' + str(e))
 
     def fuzzywuzzy_sort(self, event, opts, candidates, query):
         fuzzy = importlib.import_module('fuzzywuzzy.fuzz')


### PR DESCRIPTION
### New features
- Added `wilder#lua_fzy_highlighter()`
- Added `wilder#popupmenu_devicons()`
- Added `wilder#popupmenu_buffer_flags()`

### Fixes
- Fixed `wilder#reject_completion()` returning to the wrong completion sometimes

### Breaking changes
- `wilder#popupmenu_renderer()` columns are now called for the entire result instead of per line
- When `start_at_boundary` is `0` for `wilder#python_fuzzy_pattern()` and `wilder#python_fuzzy_delimiter_pattern()`, the characters before the pattern are included in the match
- Fuzzy completion for `buffer` now returns all buffers which are filtered, instead of using the first character of the match to get the completions before filtering

### Experimental
- Removed the consumer thread in the remote plugin in favour of directly calling `nvim.async_call`