### PR TITLE
Help tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,23 @@ code.
 
 If highlighting is important, use the Lua highlighters for best performance.
 
+### Faster Startup time
+
+Define the pipeline and renderer in an `autocmd` so the initialisation is deferred to the first `CmdlineEnter`.
+
+```vim
+" Other options should be set outside
+call wilder#set_option('modes', ...)
+
+" ++once supported in Nvim 0.4+ and Vim 8.1+
+autocmd CmdlineEnter * ++once s:wilder_init()
+
+function! s:wilder_init() abort
+  call wilder#set_option('pipeline', ...)
+  call wilder#set_option('renderer', ...)
+endfunction
+```
+
 ### Disabling in the case of errors
 
 Use `q:` to open the `cmdline-window` and enter the following command

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -513,9 +513,9 @@ function! wilder#python_search_pipeline(...) abort
   elseif l:Pattern ==# 'fuzzy'
     let l:Pattern = wilder#python_fuzzy_pattern()
   elseif l:Pattern ==# 'fuzzy_delimiter'
-    let l:Pattern ==# wilder#python_fuzzy_delimiter_pattern()
+    let l:Pattern = wilder#python_fuzzy_delimiter_pattern()
   else
-    let l:Pattern ==# wilder#python_substring_pattern()
+    let l:Pattern = wilder#python_substring_pattern()
   endif
 
   let l:Sorter = get(l:opts, 'sorter', get(l:opts, 'sort', 0))

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -189,6 +189,10 @@ function! wilder#check(...) abort
   return wilder#pipe#check#make(a:000)
 endfunction
 
+function! wilder#if(condition, p) abort
+  return {ctx, x -> a:condition ? a:p(ctx, x) : x}
+endfunction
+
 function! wilder#debounce(t) abort
   return wilder#pipe#debounce#make(a:t)
 endfunction
@@ -479,72 +483,52 @@ endfunction
 function! s:search_pipeline(...) abort
   let l:opts = a:0 > 0 ? a:1 : {}
 
-  let l:pipeline = []
-  if !get(l:opts, 'skip_cmdtype_check', 0)
-    call add(l:pipeline,
-          \ wilder#check({-> getcmdtype() ==# '/' || getcmdtype() ==# '?'}))
-  endif
-
-  if get(l:opts, 'debounce', 0) > 0
-    call add(l:pipeline, wilder#debounce(l:opts['debounce']))
-  endif
-
-  let l:pipeline += get(l:opts, 'pipeline', [
+  let l:search_pipeline = get(l:opts, 'pipeline', [
         \ wilder#vim_substring(),
         \ wilder#vim_search(),
         \ wilder#result_output_escape('^$*~[]/\'),
         \ ])
 
-  return l:pipeline
+  let l:skip_cmdtype_check = get(l:opts, 'skip_cmdtype_check', 0)
+
+  let l:should_debounce = get(l:opts, 'debounce', 0) > 0
+
+  return [
+        \ wilder#if(!l:skip_cmdtype_check,
+        \   wilder#check({-> getcmdtype() ==# '/' || getcmdtype() ==# '?'})),
+        \ wilder#if(l:should_debounce, wilder#debounce(l:opts['debounce'])),
+        \ ] + l:search_pipeline
 endfunction
 
 function! wilder#vim_search_pipeline(...) abort
   return s:search_pipeline(get(a:, 1, {}))
 endfunction
 
-function! s:extract_keys(obj, ...)
-  let l:res = {}
-
-  for l:key in a:000
-    if has_key(a:obj, l:key)
-      let l:res[l:key] = a:obj[l:key]
-    endif
-  endfor
-
-  return l:res
-endfunction
-
 function! wilder#python_search_pipeline(...) abort
   let l:opts = get(a:, 1, {})
 
-  let l:pipeline = []
-
   let l:Pattern = get(l:opts, 'pattern', get(l:opts, 'regex', 'substring'))
   if type(l:Pattern) is v:t_func
-    call add(l:pipeline, l:Pattern)
+    " pass
   elseif l:Pattern ==# 'fuzzy'
-    call add(l:pipeline, wilder#python_fuzzy_pattern())
+    let l:Pattern = wilder#python_fuzzy_pattern()
   elseif l:Pattern ==# 'fuzzy_delimiter'
-    call add(l:pipeline, wilder#python_fuzzy_delimiter_pattern())
+    let l:Pattern ==# wilder#python_fuzzy_delimiter_pattern()
   else
-    call add(l:pipeline, wilder#python_substring_pattern())
+    let l:Pattern ==# wilder#python_substring_pattern()
   endif
-
-  let l:subpipeline = []
-
-  call add(l:subpipeline, wilder#python_search(
-        \ s:extract_keys(l:opts, 'max_candidates', 'engine')))
 
   let l:Sorter = get(l:opts, 'sorter', get(l:opts, 'sort', 0))
-  if l:Sorter isnot 0
-    call add(l:subpipeline, {ctx, xs -> l:Sorter(ctx, xs, ctx.input)})
-  endif
 
-  call add(l:subpipeline, wilder#result_output_escape('^$*~[]/\'))
-
-  call add(l:pipeline, wilder#subpipeline({ctx, x -> l:subpipeline + [
-        \ wilder#result({'data': {'pcre2.pattern': x}}),
-        \ ]}))
+  let l:pipeline = [
+        \ l:Pattern,
+        \ wilder#subpipeline({ctx, x -> [
+        \   wilder#python_search(s:extract_keys(l:opts, 'max_candidates', 'engine')),
+        \   wilder#if(l:Sorter isnot 0, {ctx, xs -> l:Sorter(ctx, xs, ctx.input)}),
+        \   wilder#result_output_escape('^$*~[]/\'),
+        \   wilder#result({'data': {'pcre2.pattern': x}}),
+        \ ]}),
+        \ ]
 
   return s:search_pipeline({
         \ 'debounce': get(l:opts, 'debounce', 0),
@@ -846,4 +830,16 @@ function! wilder#draw_devicons(ctx, x, data) abort
   let l:is_dir = a:x[-1:] ==# l:slash
 
   return WebDevIconsGetFileTypeSymbol(a:x, l:is_dir) . ' ' . a:x
+endfunction
+
+function! s:extract_keys(obj, ...)
+  let l:res = {}
+
+  for l:key in a:000
+    if has_key(a:obj, l:key)
+      let l:res[l:key] = a:obj[l:key]
+    endif
+  endfor
+
+  return l:res
 endfunction

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -1093,10 +1093,10 @@ function! s:set_pcre2_pattern(data, fuzzy) abort
   let l:data = a:data is v:null ? {} : a:data
   let l:match_arg = get(l:data, 'cmdline.match_arg', '')
 
-  if l:fuzzy
+  if a:fuzzy
     let l:pcre2_pattern = s:make_python_fuzzy_regex(l:match_arg)
   else
-    let l:pcre2_pattern = '('. escape(l:match_arg), '\.^$*+?|(){}[]') . ')'
+    let l:pcre2_pattern = '('. escape(l:match_arg, '\.^$*+?|(){}[]') . ')'
   endif
 
   return extend(a:data, {'pcre2.pattern': l:pcre2_pattern})

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -356,10 +356,12 @@ function! wilder#cmdline#get_fuzzy_completion(ctx, res, getcompletion, fuzzy_mod
     return a:getcompletion(a:ctx, a:res)
   endif
 
-  if a:fuzzy_mode == 2
+  let l:fuzzy_char = get(a:res, 'fuzzy_char', '')
+
+  " Keep leading . in file expansion to search hidden directories
+  if a:fuzzy_mode == 2 &&
+        \ !(wilder#cmdline#is_file_expansion(a:res.expand) && l:fuzzy_char ==# '.')
     let l:fuzzy_char = ''
-  else
-    let l:fuzzy_char = get(a:res, 'fuzzy_char', '')
   endif
 
   if toupper(l:fuzzy_char) ==# l:fuzzy_char

--- a/autoload/wilder/pipeline.vim
+++ b/autoload/wilder/pipeline.vim
@@ -163,15 +163,11 @@ function! s:run(pipeline, on_finish, on_error, ctx, x, i) abort
   call a:on_finish(a:ctx, l:x)
 endfunction
 
-function! wilder#pipeline#wait(f, on_finish, ...) abort
+function! wilder#pipeline#wait(f, on_finish) abort
   let l:state = {
         \ 'f': a:f,
         \ 'on_finish': a:on_finish,
         \ }
-
-  if a:0
-    let l:state.on_error = a:1
-  endif
 
   return {ctx -> s:wait_start(l:state, ctx)}
 endfunction
@@ -220,11 +216,7 @@ function! s:wait_on_finish(state, ctx, x)
   try
     call a:state.on_finish(l:ctx, a:x)
   catch
-    if has_key(a:state, 'on_error')
-      call a:state.on_error(l:ctx, v:exception)
-    else
-      call wilder#reject(l:ctx, v:exception)
-    endif
+    call wilder#reject(l:ctx, v:exception)
   endtry
 endfunction
 
@@ -232,11 +224,7 @@ function! s:wait_on_error(state, ctx, x)
   let l:ctx = copy(a:ctx)
   let l:ctx.handler_id = a:state.wait_handler_id
 
-  if has_key(a:state, 'on_error')
-    call a:state.on_error(l:ctx, a:x)
-  else
-    call wilder#reject(l:ctx, a:x)
-  endif
+  call wilder#reject(l:ctx, a:x)
 endfunction
 
 function! s:echoerr(message)

--- a/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
+++ b/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
@@ -46,12 +46,12 @@ function! s:buffer_status(state, ctx, result) abort
   let l:hl = get(a:state, 'hl', a:ctx.highlights['default'])
   let l:selected_hl = get(a:state, 'selected_hl', a:ctx.highlights['selected'])
 
-  let l:empty_chunks = [[repeat(' ', l:width), l:hl, l:selected_hl]]
-
   if stridx(l:flags, '1') != -1
     let l:bufnr_width = strdisplaywidth(bufnr('$'))
     let l:width += l:bufnr_width - 1
   endif
+
+  let l:empty_chunks = [[repeat(' ', l:width), l:hl, l:selected_hl]]
 
   let l:i = l:start
   while l:i <= l:end

--- a/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
+++ b/autoload/wilder/renderer/popupmenu_column/buffer_flags.vim
@@ -57,7 +57,7 @@ function! s:buffer_status(state, ctx, result) abort
   while l:i <= l:end
     let l:index = l:i - l:start
 
-    let l:x = fnamemodify(simplify(a:result.value[l:i]), ':~')
+    let l:x = fnamemodify(a:result.value[l:i], ':~')
 
     if a:state.cache.has_key(l:x)
       let l:buffer_status[l:index] = a:state.cache.get(l:x)

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -454,6 +454,7 @@ wilder#vim_search([{options}])      *wilder#vim_search()*
 
             {options} is a dictionary with keys:
             `max_candidates`
+            Optional~
             Maximum number of candidates to return.
             0 or less sets no limit.
 
@@ -818,8 +819,10 @@ wilder#python_file_finder_pipeline([{options}])
             {options} is a dictionary with keys:
             `file_command`
             Optional~
-            A list of strings representing the command used to search for
-            files.
+            A function or a list of strings representing the command used to
+            search for files. The function should take a {ctx} and the file
+            completion argument {arg} and return the command as a list of
+            strings.
 
             To use `ripgrep`, set to this option to ['rg', '--files'].
             To use `fd`, set to this option to ['fd', '-tf'].
@@ -828,8 +831,10 @@ wilder#python_file_finder_pipeline([{options}])
 
             `dir_command`
             Optional~
-            A list of strings representing the command used to search for
-            directories.
+            A function or a list of strings representing the command used to
+            search for directories. The function should take a {ctx} and the
+            directory completion argument {arg} and return the command as a
+            list of strings.
 
             To use `fd`, set to this option to ['fd', '-td'].
 

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -625,6 +625,13 @@ wilder#vim_search_pipeline([{options}])
 
             Default: 0
 
+            `debounce`
+            Optional~
+            An interval in milliseconds. If greater than 0, debounces the
+            pipeline using |wilder#debounce()|.
+
+            Default: 0
+
 wilder#python_search_pipeline([{options}])
                                     *wilder#python_search_pipeline()*
                                     Neovim only~
@@ -780,6 +787,13 @@ wilder#cmdline_pipeline([{options}])
             PCRE2.
 
             Default: 1
+
+            `debounce`
+            Optional~
+            An interval in milliseconds. If greater than 0, debounces the
+            pipeline using |wilder#debounce()|.
+
+            Default: 0
 
             `sort`
             Deprecated: Use `sorter`.

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1909,23 +1909,26 @@ wilder#reject({ctx}, {err})         *wilder#reject()*
             |wilder-pipeline|.
             See |wilder-pipeline-thunk|.
 
-wilder#wait({f}, [{on_finish}, [{on_error}]])
+wilder#wait({f}, {on_finish})
                                     *wilder#wait()*
                                     Experimental~
-            If {f} is not a function, calls {on_finish} with it if provided,
-            otherwise calls |wilder#resolve()|.
+            {on_finish} should be a function that takes a {ctx} and the result
+            of {f} and eventually calls |wilder#resolve()|.
+
+            If {f} is not a function, calls {on_finish} with {f}.
 
             If {f} is a function, calls it as a |wilder-pipeline-thunk|. When
-            the thunk resolves, it will call {on_finish} if provided,
-            otherwise it calls |wilder#resolve()|. If there is an error, calls
-            {on_error} if provided, otherwise it calls |wilder#reject()|.
+            the thunk resolves, it will call {on_finish} with the resolved
+            result.
+
+            If there is an error, calls |wilder#reject()| with the error.
 
             This can be used to wait for thunks within another thunk.
             Example:
 >
             function! Foo(ctx, x) abort
               return wilder#wait(Bar, {ctx, result_of_bar ->
-                    \  wilder#resolve(Baz(result_of_bar))})
+                    \  wilder#resolve(ctx, Baz(result_of_bar))})
             endfunction
 <
 

--- a/lua/wilder.lua
+++ b/lua/wilder.lua
@@ -57,6 +57,10 @@ end
 local function fzy_highlight(needle, haystack)
   local fzy = require('fzy-lua-native')
 
+  if not fzy.has_match(needle, haystack) then
+    return 0
+  end
+
   local positions = fzy.positions(needle, haystack)
 
   if #positions == 0 then

--- a/rplugin/python3/wilder/__init__.py
+++ b/rplugin/python3/wilder/__init__.py
@@ -39,7 +39,7 @@ class Wilder(object):
         self.run_id = -1
         self.find_files_lock = threading.Lock()
         self.find_files_session_id = -1
-        self.path_files_dict = dict()
+        self.find_files_cache = dict()
         self.help_tags_lock = threading.Lock()
         self.help_tags_session_id = -1
         self.help_tags_result = None
@@ -130,18 +130,18 @@ class Wilder(object):
                 if ctx['session_id'] > self.find_files_session_id:
                     self.find_files_session_id = ctx['session_id']
 
-                    for result in self.path_files_dict.values():
+                    for result in self.find_files_cache.values():
                         result['kill'].set()
 
-                    self.path_files_dict = dict()
+                    self.find_files_cache = dict()
 
-                if key in self.path_files_dict:
-                    result = self.path_files_dict[key]
+                if key in self.find_files_cache:
+                    result = self.find_files_cache[key]
                 else:
                     kill_event = threading.Event()
                     done_event = threading.Event()
                     result = {'kill': kill_event, 'done': done_event}
-                    self.path_files_dict[key] = result
+                    self.find_files_cache[key] = result
                     self.executor.submit(functools.partial( self.find_files_subprocess, *([command, path, timeout_ms, result]), ))
 
             while True:


### PR DESCRIPTION
### New features
- `wilder#cmdline_pipeline()` now supports fuzzy completion for `:help`
- Added `debounce` option for `wilder#cmdline_pipeline()`
- `wilder#python_file_finder()` `file_command` and `dir_command` options now accept functions

### Fixes
- Fixed `wilder#fzy_highlighter()` highlighting wrongly sometimes
- Fixed `wilder#popupmenu_buffer_flags()` having wrong width sometimes
- Fixed `wilder#popupmenu_buffer_flags()` not detecting buffers with url names
- Fixed `wilder#cmdline_pipeline()` not finding hidden files with option `'fuzzy:' 2`

### Breaking changes
- `wilder#wait()` no longer takes `on_error` argument