### PR TITLE
Renderer item dynamic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,13 @@ Other available highlighters are `wilder#python_pcre2_highlighter()` and
 
 # Tips
 
-### Input latency
+### Reducing input latency
 
 Input latency when typing in the cmdline is due to `wilder` rendering synchronously.
 Rendering time increases for each `wilder#wildmenu_renderer()` item, `wilder#popupmenu_renderer()` column,
 or by having a slow `highlighter`.
+
+#### Use minimal configuration
 
 The fastest configuration for `wilder` is to use the non-fuzzy Python pipelines
 and the default renderers.
@@ -298,6 +300,40 @@ implement a faster renderer e.g. using Lua or to improve the current rendering
 code.
 
 If highlighting is important, use the Lua highlighters for best performance.
+
+Avoid `wilder#wildmenu_spinner()` and `wilder#popupmenu_spinner()` as they cause frequent re-renders.
+
+#### Use debounce
+
+Use `wilder#debounce()` or the `debounce` option in pipelines to avoid rendering too often.
+The `debounce` option is currently supported by `wilder#search_pipeline()` (both `vim` and `python`),
+`wilder#cmdline_pipeline()` and `wilder#python_file_finder_pipeline()`.
+The debounce interval is in milliseconds.
+
+There is a tradeoff in increased latency for the final result due to the debounce versus the
+increased input latency per character typed due to the rendering of intermediate results.
+
+```vim
+" Debounce the whole pipeline
+call wilder#set_option('pipeline', [
+      \ wilder#debounce(10),
+      \ wilder#branch([
+      \   ...
+      \ ]),
+      \ ])
+
+" Or debounce individual pipelines
+call wilder#set_option('pipeline', [
+      \   wilder#branch(
+      \     wilder#cmdline_pipeline({
+      \       'debounce': 10,
+      \     }),
+      \     wilder#search_pipeline({
+      \       'debounce': 10,
+      \     }),
+      \   ),
+      \ ])
+```
 
 ### Faster Startup time
 

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -194,7 +194,7 @@ function! wilder#cmdline#prepare_file_completion(ctx, res, fuzzy)
 
   " Check if tail is trying to complete an env var.
   let l:matches = matchlist(l:tail, '\$\(\f*\)$')
-  if len(l:matches) >= 2
+  if len(l:matches)
     let l:env_var = l:matches[1]
     let l:path_prefix = l:arg[:-len(l:env_var)-1]
 
@@ -408,6 +408,10 @@ function! wilder#cmdline#python_get_file_completion(ctx, res) abort
 endfunction
 
 function! wilder#cmdline#getcompletion(ctx, res) abort
+  if has_key(a:res, 'completions')
+    return a:res['completions']
+  endif
+
   let l:expand_arg = a:res.expand_arg
 
   " getting all shellcmds takes a significant amount of time
@@ -607,7 +611,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
 
     return []
   elseif a:res.expand ==# 'user_commands'
-    return filter(getcompletion(l:expand_arg, 'command'), {_, x -> !(x[0] >= 'a' && x[0] <= 'z')})
+    return filter(getcompletion(l:expand_arg, 'command'), {_, x -> x[0] >=# 'A' && x[0] <=# 'Z'})
   elseif a:res.expand ==# 'tags' ||
         \ a:res.expand ==# 'tags_listfiles'
     " tags_listfiles is only used for c_CTRL-D
@@ -1016,9 +1020,11 @@ function! wilder#cmdline#getcompletion_pipeline(opts) abort
         \ wilder#if(l:fuzzy, wilder#result({
         \   'value': {ctx, xs, data -> l:Filter(
         \     ctx, xs, get(data, 'cmdline.path_prefix', '') . get(data, 'cmdline.match_arg', ''))},
+        \ })),
+        \ wilder#result({
         \   'output': [{_, x -> escape(x, ' ')}],
         \   'draw': ['wilder#cmdline#draw_path'],
-        \ })),
+        \ }),
         \ ]
 
   " parsed cmdline

--- a/autoload/wilder/cmdline/match.vim
+++ b/autoload/wilder/cmdline/match.vim
@@ -1,19 +1,22 @@
 function! wilder#cmdline#match#do(ctx) abort
-  if a:ctx.pos < len(a:ctx.cmdline) &&
-        \ (a:ctx.cmdline[a:ctx.pos] !=# '|' &&
-        \ a:ctx.cmdline[a:ctx.pos] !=# '"')
-    call wilder#cmdline#highlight#do(a:ctx)
+  let l:arg_start = a:ctx.pos
 
-    if wilder#cmdline#main#skip_nonwhitespace(a:ctx) &&
-          \ wilder#cmdline#main#skip_whitespace(a:ctx)
-      let l:delimiter = a:ctx.cmdline[a:ctx.pos]
-      let a:ctx.expand = 'nothing'
-      let a:ctx.pos += 1
-
-      call wilder#cmdline#skip_regex#do(a:ctx, l:delimiter)
-    endif
+  " TODO? :h :match - watch out for special characters " and |
+  if !wilder#cmdline#main#skip_nonwhitespace(a:ctx)
+    let a:ctx.expand = 'highlight'
+    let a:ctx.pos = l:arg_start
+    return
   endif
 
+  if wilder#cmdline#main#skip_whitespace(a:ctx)
+    let l:delimiter = a:ctx.cmdline[a:ctx.pos]
+    let a:ctx.expand = 'nothing'
+    let a:ctx.pos += 1
+
+    call wilder#cmdline#skip_regex#do(a:ctx, l:delimiter)
+  endif
+
+  " Skip to trailing |, if any
   while a:ctx.pos < len(a:ctx.cmdline) &&
         \ a:ctx.cmdline[a:ctx.pos] !=# '|'
     let a:ctx.pos += 1

--- a/autoload/wilder/cmdline/unlet.vim
+++ b/autoload/wilder/cmdline/unlet.vim
@@ -1,5 +1,18 @@
 function! wilder#cmdline#unlet#do(ctx) abort
-  call wilder#cmdline#main#find_last_whitespace(a:ctx)
+  let l:last_arg = a:ctx.pos
+
+  " find start of last argument
+  while a:ctx.pos < len(a:ctx.cmdline)
+    let l:char = a:ctx.cmdline[a:ctx.pos]
+
+    let a:ctx.pos += 1
+
+    if l:char ==# ' ' || l:char ==# "\t"
+      let l:last_arg = a:ctx.pos
+    endif
+  endwhile
+
+  let a:ctx.pos = l:last_arg
 
   if a:ctx.cmdline[a:ctx.pos] ==# '$'
     let a:ctx.expand = 'environment'

--- a/autoload/wilder/renderer/popupmenu.vim
+++ b/autoload/wilder/renderer/popupmenu.vim
@@ -56,7 +56,7 @@ function! s:prepare_state(opts) abort
     endif
   endif
 
-  let l:min_width = get(a:opts, 'min_width', 0)
+  let l:min_width = get(a:opts, 'min_width', 16)
   if type(l:min_width) is v:t_number
     let l:state.get_min_width = {-> l:min_width}
   else
@@ -76,6 +76,8 @@ function! s:prepare_state(opts) abort
     let l:state.left = get(a:opts, 'left', [])
     let l:state.right = get(a:opts, 'right', [])
   endif
+
+  let l:state.dynamic = s:has_dynamic_column(l:state)
 
   if !has_key(l:state.highlights, 'accent')
     let l:state.highlights.accent =
@@ -168,6 +170,10 @@ function! s:render(state, ctx, result) abort
 
   if l:page == [-1, -1]
     call s:close_win(a:state)
+    return
+  endif
+
+  if !a:ctx.done && !a:state.dynamic
     return
   endif
 
@@ -641,4 +647,16 @@ function! s:get_cmdheight() abort
   endif
 
   return l:cmdheight
+endfunction
+
+function! s:has_dynamic_column(state) abort
+  for l:Column in a:state.left + a:state.right
+    if type(l:Column) is v:t_dict &&
+          \ has_key(l:Column, 'dynamic') &&
+          \ l:Column['dynamic']
+      return 1
+    endif
+  endfor
+
+  return 0
 endfunction

--- a/autoload/wilder/renderer/popupmenu_column/spinner.vim
+++ b/autoload/wilder/renderer/popupmenu_column/spinner.vim
@@ -12,7 +12,7 @@ function! wilder#renderer#popupmenu_column#spinner#make(opts) abort
 
   let l:state = {
         \ 'frames': l:frames,
-        \ 'done': get(a:opts, 'done', ' '),
+        \ 'done': get(a:opts, 'done', ''),
         \ 'spinner': l:spinner,
         \ 'align': get(a:opts, 'align', 'bottom'),
         \ }
@@ -27,6 +27,7 @@ function! wilder#renderer#popupmenu_column#spinner#make(opts) abort
 
   return {
         \ 'value': {ctx, result -> s:spinner(l:state, ctx, result)},
+        \ 'dynamic': 1,
         \ }
 endfunction
 

--- a/autoload/wilder/renderer/popupmenu_column/spinner.vim
+++ b/autoload/wilder/renderer/popupmenu_column/spinner.vim
@@ -12,7 +12,7 @@ function! wilder#renderer#popupmenu_column#spinner#make(opts) abort
 
   let l:state = {
         \ 'frames': l:frames,
-        \ 'done': get(a:opts, 'done', ''),
+        \ 'done': get(a:opts, 'done', ' '),
         \ 'spinner': l:spinner,
         \ 'align': get(a:opts, 'align', 'bottom'),
         \ }
@@ -43,7 +43,11 @@ function! s:spinner(state, ctx, result) abort
     let l:frame = a:state.frames[l:frame_number]
   endif
 
-  let l:column_chunks = repeat([[['']]], l:height)
+  let l:width = strdisplaywidth(l:frame)
+
+  let l:spaces = repeat(' ', l:width)
+
+  let l:column_chunks = repeat([[[l:spaces]]], l:height)
 
   if a:state.align ==# 'bottom'
     let l:column_chunks[-1] = [[l:frame]]

--- a/autoload/wilder/renderer/wildmenu.vim
+++ b/autoload/wilder/renderer/wildmenu.vim
@@ -24,6 +24,9 @@ function! wilder#renderer#wildmenu#prepare_state(args) abort
     let l:state.right = get(a:args, 'right', [])
   endif
 
+  let l:state.dynamic = wilder#renderer#wildmenu#item_is_dynamic(l:state.left) ||
+        \ wilder#renderer#wildmenu#item_is_dynamic(l:state.right)
+
   if !has_key(l:state.highlights, 'separator')
     let l:state.highlights.separator =
           \ get(a:args, 'separator_hl', l:state.highlights['default'])
@@ -143,6 +146,24 @@ function! wilder#renderer#wildmenu#item_len(item, ctx, result) abort
   endfor
 
   return l:len
+endfunction
+
+function! wilder#renderer#wildmenu#item_is_dynamic(item) abort
+  if type(a:item) is v:t_dict
+    return has_key(a:item, 'dynamic') && a:item['dynamic']
+  endif
+
+  if type(a:item) is v:t_list
+    for l:Elem in a:item
+      if wilder#renderer#wildmenu#item_is_dynamic(l:Elem)
+        return 1
+      endif
+    endfor
+
+    return 0
+  endif
+
+  return 0
 endfunction
 
 function! wilder#renderer#wildmenu#item_pre_hook(item, ctx) abort

--- a/autoload/wilder/renderer/wildmenu_float.vim
+++ b/autoload/wilder/renderer/wildmenu_float.vim
@@ -18,6 +18,10 @@ function! s:render(state, ctx, result) abort
     return
   endif
 
+  if !a:ctx.done && !a:state.dynamic
+    return
+  endif
+
   let l:chunks = wilder#renderer#wildmenu#make_hl_chunks(
         \ a:state, &columns, a:ctx, a:result)
 

--- a/autoload/wilder/renderer/wildmenu_item/condition.vim
+++ b/autoload/wilder/renderer/wildmenu_item/condition.vim
@@ -6,10 +6,14 @@ function! wilder#renderer#wildmenu_item#condition#make(predicate, if_true, if_fa
         \ 'chosen': [],
         \ }
 
+  let l:dynamic = wilder#renderer#wildmenu#item_is_dynamic(a:if_true) ||
+        \ wilder#renderer#wildmenu#item_is_dynamic(a:if_false)
+
   return {
         \ 'value': {ctx, result -> s:value(l:state, ctx, result)},
         \ 'pre_hook': {ctx -> s:pre_hook(l:state, ctx)},
         \ 'post_hook': {ctx -> s:post_hook(l:state, ctx)},
+        \ 'dynamic': l:dynamic,
         \ }
 endfunction
 

--- a/autoload/wilder/renderer/wildmenu_item/spinner.vim
+++ b/autoload/wilder/renderer/wildmenu_item/spinner.vim
@@ -26,6 +26,7 @@ function! wilder#renderer#wildmenu_item#spinner#make(args) abort
         \ 'hl': get(a:args, 'hl', ''),
         \ 'pre_hook': {ctx -> s:pre_hook(l:state, ctx)},
         \ 'post_hook': {ctx -> s:post_hook(l:state, ctx)},
+        \ 'dynamic': 1,
         \ }
 endfunction
 

--- a/autoload/wilder/renderer/wildmenu_statusline.vim
+++ b/autoload/wilder/renderer/wildmenu_statusline.vim
@@ -9,6 +9,10 @@ function! wilder#renderer#wildmenu_statusline#make(args) abort
 endfunction
 
 function! s:render(state, ctx, result) abort
+  if !a:ctx.done && !a:state.dynamic
+    return
+  endif
+
   let l:chunks = wilder#renderer#wildmenu#make_hl_chunks(
         \ a:state, winwidth(0), a:ctx, a:result)
 

--- a/autoload/wilder/renderer/wildmenu_theme.vim
+++ b/autoload/wilder/renderer/wildmenu_theme.vim
@@ -122,24 +122,30 @@ function! s:theme(opts, namespace, hls) abort
 
   let l:theme = {
         \ 'left': [
-        \   {'value': [
-        \     wilder#condition(
-        \       {-> getcmdtype() ==# ':'},
-        \       ' COMMAND ',
-        \       ' SEARCH ',
-        \     ),
-        \     wilder#condition(
-        \       {ctx, x -> has_key(ctx, 'error')},
-        \       '!',
-        \       wilder#wildmenu_spinner()
-        \     ), ' '],
-        \   'hl': l:highlights['mode']
+        \   {
+        \     'value': [
+        \       wilder#condition(
+        \         {-> getcmdtype() ==# ':'},
+        \         ' COMMAND ',
+        \         ' SEARCH ',
+        \       ),
+        \       wilder#condition(
+        \         {ctx, x -> has_key(ctx, 'error')},
+        \         '!',
+        \         wilder#wildmenu_spinner()
+        \       ), ' '],
+        \     'hl': l:highlights['mode'],
+        \     'dynamic': 1,
         \   },
-        \   l:separators[0], l:separators[1], ' ', 
+        \   l:separators[0],
+        \   l:separators[1],
+        \   ' ', 
         \ ],
         \ 'right': [
-        \   ' ',  l:separators[2], l:separators[3],
-        \    wilder#index({'hl': l:highlights['index']}),
+        \   ' ',
+        \   l:separators[2],
+        \   l:separators[3],
+        \   wilder#index({'hl': l:highlights['index']}),
         \ ],
         \ }
 

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1643,7 +1643,7 @@ wilder#popupmenu_renderer([{options}])
 
             Setting to 0 indicates no minimum width.
 
-            Default: 0
+            Default: 16
 
 
                                     *wilder#wildmenu_renderer()-column*

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1362,6 +1362,14 @@ For |wilder#wildmenu_renderer()|, items can be of the following types:
 
                 Default: None
 
+                `dynamic`
+                Optional~
+                Whether the item needs to update even when pipeline is not
+                done. For example, |wilder#wildmenu_spinner()| needs to set
+                this to 1 since the spinner frames need to be updated.
+
+                Default: 0
+
             Function:
             A function which takes a {ctx} and the pipeline result {result}
             and returns a item.
@@ -1694,6 +1702,14 @@ For |wilder#popupmenu_renderer()|, columns can be of the following types:
                 {ctx} contains no keys.
 
                 Default: None
+
+                `dynamic`
+                Optional~
+                Whether the item needs to update even when pipeline is not
+                done. For example, |wilder#popupmenu_spinner()| needs to set
+                this to 1 since the spinner frames need to be updated.
+
+                Default: 0
 
                                     *wilder#popupmenu_scrollbar()*
 wilder#popupmenu_scrollbar([{options}]


### PR DESCRIPTION
### Fixes
- Various fixes to `wilder#cmdline_pipeline()` completion giving wrong or extra candidates
- Fixed `<Tab>` not working when falling back to default wildmenu in command completions. This occurs when the command completion fails due to script-local variables or functions.

### Breaking changes
- `wilder#popupmenu_renderer()` columns and `wilder#wildmenu_renderer()` items can now set the `dynamic` option. This is needed for items which need to update independently of the pipeline (e.g. `wilder#wildmenu_spinner()`). If none of the items are `dynamic`, the renderer can skip extra redraws.
- `wilder#popupmenu_spinner()` now takes the width of the current spinner frame instead of collasping to 0 width
- `wilder#popupmenu_renderer()` `min_width` option changed to 16 to follow Nvim