### PR TITLE
File finder changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ For example, in Neovim, to use fuzzy matching instead of substring matching:
 ```vim
 " For Neovim only
 " For wild#cmdline_pipeline():
+"   'language'   : set to 'python' to use python
 "   'fuzzy'      : set fuzzy searching
-"   'use_python' : use python for fuzzy searching
 " For wild#python_search_pipeline():
 "   'pattern'    : can be set to wilder#python_fuzzy_delimiter_pattern() for stricter fuzzy matching
 "   'sorter'     : omit to get results in the order they appear in the buffer
@@ -67,8 +67,8 @@ For example, in Neovim, to use fuzzy matching instead of substring matching:
 call wilder#set_option('pipeline', [
       \   wilder#branch(
       \     wilder#cmdline_pipeline({
+      \       'language': 'python',
       \       'fuzzy': 1,
-      \       'use_python': 1,
       \     }),
       \     wilder#python_search_pipeline({
       \       'pattern': wilder#python_fuzzy_pattern(),
@@ -283,7 +283,7 @@ and the default renderers.
 " Neovim only
 call wilder#set_option('pipeline', [
       \   wilder#branch(
-      \     wilder#cmdline_pipeline({'use_python': 1}),
+      \     wilder#cmdline_pipeline({'language': 'python'}),
       \     wilder#python_search_pipeline(),
       \   ),
       \ ])

--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ call wilder#set_option('renderer', wilder#wildmenu_renderer({
 
 ![Minimal](https://i.imgur.com/AifaC11.png)
 
-For Airline and Lightline users, `wilder#airline_theme()` and `wilder#lightline_theme()` can be used.
+For Airline and Lightline users, `wilder#wildmenu_airline_theme()` and `wilder#wildmenu_lightline_theme()` can be used.
 
 ```vim
-" use wilder#lightline_theme() if using Lightline
+" use wilder#wildmenu_lightline_theme() if using Lightline
 " 'highlights' : can be overriden, see :h wilder#wildmenu_renderer()
 call wilder#set_option('renderer', wilder#wildmenu_renderer(
-      \ wilder#airline_theme({
+      \ wilder#wildmenu_airline_theme({
       \   'highlights': {},
       \   'highlighter': wilder#basic_highlighter(),
       \   'separator': ' · ',

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -688,12 +688,22 @@ function! wilder#popupmenu_renderer(...)
   return wilder#renderer#popupmenu#make(l:args)
 endfunction
 
+" DEPRECATED: use wilder#wildmenu_airline_theme()
 function! wilder#airline_theme(...)
+  return call('wilder#wildmenu_airline_theme', a:000)
+endfunction
+
+function! wilder#wildmenu_airline_theme(...)
   let l:args = get(a:000, 0, {})
   return wilder#renderer#wildmenu_theme#airline_theme(l:args)
 endfunction
 
+" DEPRECATED: use wilder#wildmenu_lightline_theme()
 function! wilder#lightline_theme(...)
+  return call('wilder#wildmenu_lightline_theme', a:000)
+endfunction
+
+function! wilder#wildmenu_lightline_theme(...)
   let l:args = get(a:000, 0, {})
   return wilder#renderer#wildmenu_theme#lightline_theme(l:args)
 endfunction

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -1023,7 +1023,13 @@ function! s:simplify(path)
 endfunction
 
 function! wilder#cmdline#getcompletion_pipeline(opts) abort
-  let l:use_python = get(a:opts, 'use_python', has('nvim'))
+  if has_key(a:opts, 'language')
+    let l:use_python = a:opts['language'] ==# 'python'
+  elseif has_key(a:opts, 'use_python')
+    let l:use_python = a:opts['use_python']
+  else
+    let l:use_python = has('nvim')
+  endif
 
   let l:fuzzy = get(a:opts, 'fuzzy', 0)
   if l:fuzzy

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -804,20 +804,11 @@ function wilder#cmdline#should_use_file_finder(res) abort
 
   let l:path = a:res.expand_arg
 
-  " ./. simplifies to .
-  if l:path ==# './.' ||
-        \ l:path ==# '.\.'
-    return 0
-  endif
-
-  let l:path = simplify(l:path)
-
-  if l:path[0] ==# '~' ||
+  " Prevent scanning of filesystem accidentally.
+  if l:path ==# '~' ||
         \ l:path[0] ==# '/' ||
         \ l:path[0] ==# '\' ||
-        \ l:path[0:1] ==# '..' ||
-        \ l:path[0:1] ==# './' ||
-        \ l:path[0:1] ==# '.\'
+        \ l:path[0:1] ==# '..'
     return 0
   endif
 
@@ -925,6 +916,8 @@ function! wilder#cmdline#python_file_finder_pipeline(opts) abort
     endfor
 
     let l:opts['filters'] = l:checked_filters
+  else
+    let l:opts['filters'] = [{'name': 'fuzzy_filter', 'opts': {}}, {'name': 'difflib_sorter', 'opts': {}}]
   endif
 
   if !has_key(l:opts, 'path')
@@ -970,35 +963,63 @@ function! wilder#cmdline#python_file_finder_pipeline(opts) abort
         \   wilder#result({
         \     'pos': res.pos,
         \     'replace': ['wilder#cmdline#replace'],
-        \     'data': extend(s:convert_result_to_data(res), {'query': expand(simplify(res.arg))}),
+        \     'data': extend(s:convert_result_to_data(res), {'query': expand(res.arg)}),
         \   }),
         \ ]}),
         \ ]
 endfunction
 
 function! s:file_finder(ctx, opts, res) abort
-  let l:opts = copy(a:opts)
-
   let l:cwd = getcwd()
-  let l:path = l:opts['path'](a:ctx, a:res)
-  let l:match_arg = expand(simplify(a:res.arg))
+  let l:match_arg = expand(a:res.arg)
   let l:is_dir = a:res.expand ==# 'dir'
 
-  if !l:is_dir && has_key(l:opts, 'file_command')
-    let l:File_command = l:opts['file_command']
-
-    if type(l:File_command) is v:t_func
-      let l:opts['file_command'] = l:File_command(a:ctx, a:res.arg)
+  if !l:is_dir
+    if has_key(a:opts, 'file_command')
+      let l:Command = a:opts['file_command']
+    else
+      let l:Command = ['find', '.', '-type', 'f', '-printf', '%P\\n']
     endif
-  elseif l:is_dir && has_key(l:opts, 'dir_command')
-    let l:Dir_command = l:opts['dir_command']
-
-    if type(l:Dir_command) is v:t_func
-      let l:opts['dir_command'] = l:Dir_command(a:ctx, a:res.arg)
+  else
+    if has_key(a:opts, 'dir_command')
+      let l:Command = a:opts['dir_command']
+    else
+      let l:Command = ['find', '.', '-type', 'd', '-printf', '%P\\n']
     endif
   endif
 
-  return {ctx -> _wilder_python_file_finder(ctx, l:opts, l:cwd, l:path, l:match_arg, l:is_dir)}
+  if type(l:Command) is v:t_func
+    let l:Command = l:Command(a:ctx, l:match_arg)
+
+    if l:Command is v:false
+      return v:false
+    endif
+  endif
+
+  let l:path = a:opts['path'](a:ctx, l:match_arg)
+
+  let l:opts = {
+        \ 'timeout': get(a:opts, 'timeout', 5000),
+        \ }
+
+  return {ctx -> _wilder_python_file_finder(ctx, l:opts, l:Command, a:opts['filters'],
+        \ l:cwd, l:path, l:match_arg, l:is_dir)}
+endfunction
+
+function! s:simplify(path)
+  let l:path = simplify(a:path)
+
+  let l:slash = !has('win32') && !has('win64')
+        \ ? '/'
+        \ : &shellslash
+        \ ? '/'
+        \ : '\'
+
+  if a:path[-2:-1] ==# '/.' || a:path[-2:-1] ==# l:slash . '.'
+    let l:path .= a:path[-2:-1]
+  endif
+
+  return l:path
 endfunction
 
 function! wilder#cmdline#getcompletion_pipeline(opts) abort

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1227,10 +1227,10 @@ wilder#wildmenu_renderer([{options}])
             Deprecated~
             Use `highlighter`.
 
-                                    *wilder#airline_theme()*
-                                    *wilder#lightline_theme()*
-wilder#airline_theme([{options}])
-wilder#lightline_theme([{options}])
+                                    *wilder#wildmenu_airline_theme()*
+                                    *wilder#wildmenu_lightline_theme()*
+wilder#wildmenu_airline_theme([{options}])
+wilder#wildmenu_lightline_theme([{options}])
                                     Wildmenu renderer theme~
             Returns an object which can be passed to
             |wilder#wildmenu_renderer()| to styles the renderer to look like
@@ -1308,7 +1308,7 @@ wilder#lightline_theme([{options}])
             Example:
 >
             call wilder#set_option('renderer', wilder#wildmenu_renderer(
-                  \ wilder#airline_theme({
+                  \ wilder#wildmenu_airline_theme({
                   \   'highlights': {'default': 'Statusline'},
                   \   'separator': '  ',
                   \ })))
@@ -2634,6 +2634,14 @@ wilder#condition({predicate}, {if_true}, [{if_false}])
                                     Deprecated~
             Deprecated: Use |wilder#wildmenu_condition()|.
 
+                                    *wilder#wildmenu_airline_theme()*
+                                    *wilder#wildmenu_lightline_theme()*
+                                    Deprecated~
+wilder#wildmenu_airline_theme([{options}])
+wilder#wildmenu_lightline_theme([{options}])
+            Deprecated: Use |wilder#wildmenu_airline_theme()| or
+            |wilder#wildmenu_lightline_theme()|.
+
 
 ==============================================================================
 8. Configurations                   *wilder-configurations*
@@ -2674,9 +2682,9 @@ Pipelines (Neovim only)~
 
 Airline/Lightline Theme for Wildmenu Renderer~
 >
-    " use wilder#lightline_theme() for Lightline
+    " use wilder#wildmenu_lightline_theme() for Lightline
     call wilder#set_option('renderer', wilder#wildmenu_renderer(
-          \ wilder#airline_theme({
+          \ wilder#wildmenu_airline_theme({
           \   'highlighter': wilder#basic_highlighter(),
           \   'separator': ' · ',
           \ })))

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -819,9 +819,8 @@ wilder#python_file_finder_pipeline([{options}])
             used when the cmdline is expanding `file` or `dir` completions,
             which for example occurs when in the |:edit| or |:cd| commands.
 
-            If the path for the argument is not relative to the current
-            directory, or cannot be resolved as a descendant of the current
-            path, or starts with './', the pipeline will return |v:false|.
+            If the path for the argument starts with '~', '/' or '..', the
+            pipeline will return |v:false|.
 
             Note |wilder#python_file_finder_pipeline()| should be placed in
             front of |wilder#cmdline_pipeline()| when using |wilder#branch()|.

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -10,7 +10,7 @@ wilder                                *wilder*
 4. Pipeline                         |wilder-pipeline|
 5. Renderer                         |wilder-renderer|
 6. API                              |wilder-api|
-7. Depcrecated                      |wilder-deprecated|
+7. Deprecated                       |wilder-deprecated|
 8. Configurations                   |wilder-configurations|
 
 ==============================================================================
@@ -695,10 +695,12 @@ wilder#python_search_pipeline([{options}])
             Default: 0
 
             `sort`
-            Deprecated: Use `sorter`.
+            Deprecated~
+            Use `sorter`.
 
             `regex`
-            Deprecated: Use `pattern`.
+            Deprecated~
+            Use `pattern`.
 
                                     *wilder#cmdline_pipeline()*
 wilder#cmdline_pipeline([{options}])
@@ -716,6 +718,7 @@ wilder#cmdline_pipeline([{options}])
 
             {options} is a dictionary with keys:
             `fuzzy`
+            Optional~
             0, 1, or 2 representing the fuzzy matching mode. If 0, fuzzy
             matching is disabled. If 1, fuzzy matching is done and candidates
             have to start with the first character of the query. If 2, the
@@ -731,14 +734,16 @@ wilder#cmdline_pipeline([{options}])
 
             Default: 0
 
-            `use_python`
-            Neovim only~
-            Use async Python to get file or directory completions and for
-            fuzzy fitering.
+            `language`
+            Optional~
+            python option only for Neovim~
+            'python' or 'vim' representing the language to use for getting
+            completions and filtering.
 
-            Default: has('nvim')
+            Default: has('nvim') ? 'python' : 'vim'
 
             `fuzzy_filter`
+            Optional~
             The function to use when matching candidates in fuzzy completion.
             Takes a {ctx}, {candidates} and {query} and returns the list of
             filtered candidates. 
@@ -753,7 +758,7 @@ wilder#cmdline_pipeline([{options}])
                   \ SomeCondition(x)})
             endfunction
 <
-            Default: |wilder#python_fuzzy_filter()| if `use_python` is true
+            Default: |wilder#python_fuzzy_filter()| if `language` is 'python'
                      |wilder#fuzzy_filter()| otherwise
 
             `hide_in_substitute`
@@ -797,7 +802,12 @@ wilder#cmdline_pipeline([{options}])
             Default: 0
 
             `sort`
-            Deprecated: Use `sorter`.
+            Deprecated~
+            Use `sorter`.
+
+            `use_python`
+            Deprecated~
+            Use `language`.
 
                                     *wilder#python_file_finder_pipeline()*
 wilder#python_file_finder_pipeline([{options}])
@@ -862,7 +872,7 @@ wilder#python_file_finder_pipeline([{options}])
             gather the files from. If it is a string, it will be converted to
             a function which returns the string.
 
-            The function should take {ctx} and {res} as arguments and return
+            The function should take {ctx} and {path} as arguments and return
             the directory to search in. The directory path should be an
             absolute path and not a relative one.  Returning an empty string
             will search in the current directory.
@@ -1198,19 +1208,24 @@ wilder#wildmenu_renderer([{options}])
             Default: []
 
             `hl`
-            Deprecated: Use `highlights`.
+            Deprecated~
+            Use `highlights`.
 
             `selected_hl`
-            Deprecated: Use `highlights`.
+            Deprecated~
+            Use `highlights`.
 
             `error_hl`
-            Deprecated: Use `highlights`.
+            Deprecated~
+            Use `highlights`.
 
             `separator_hl`
-            Deprecated: Use `highlights`.
+            Deprecated~
+            Use `highlights`.
 
             `apply_highlights`
-            Deprecated: Use `highlighter`.
+            Deprecated~
+            Use `highlighter`.
 
                                     *wilder#airline_theme()*
                                     *wilder#lightline_theme()*
@@ -2512,7 +2527,7 @@ wilder#renderer_mux({args})         *wilder#renderer_mux()*
 
 
 ==============================================================================
-7. Depcrecated                      *wilder-deprecated*
+7. Deprecated                       *wilder-deprecated*
 
 wilder#vim_substring()              *wilder#vim_substring()*
                                     Deprecated~
@@ -2647,8 +2662,8 @@ Pipelines (Neovim only)~
           \       wilder#history(100),
           \     ],
           \     wilder#cmdline_pipeline({
+          \       'language': 'python',
           \       'fuzzy': 1,
-          \       'use_python': 1,
           \     }),
           \     wilder#python_search_pipeline({
           \       'fuzzy': 1,


### PR DESCRIPTION
### Breaking Changes
- `wilder#python_file_finder()` now always searches under the current project path unless the path argument starts with `~`, `/` or `..`
- `wilder#python_file_finder()` no longer tries to simplify the path (e.g. `foo/../../..` is not simplified to `../..`).
  This also means `./` does not trigger the fallback to the normal cmdline completion.
  To restore the same behavior with `./`, you can set the `file_command` option to `{_, path -> path[0:1] ==# './' ? v:false : ['find', '.', '-type', 'f', '-printf', '%P\n']}`.

### Deprecated
- `wilder#airline_theme()` and `wilder#lightline_theme()` are renamed to `wilder#wildmenu_airline_theme()` and `wilder#wildmenu_lightline_theme()` respectively.
- `use_python` option for `wilder#cmdline_pipeline()` changed to `language`.