### PR TITLE
Tag completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   - customisable look and appearance
 - Async query support - uses Python 3 remote plugin for faster and non-blocking queries
 
-![wilder](https://i.imgur.com/5kkjB7X.gif)
+![wilder](https://i.imgur.com/LkOOU6G.gif)
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,120 @@ call wilder#set_option('renderer', wilder#popupmenu_renderer({
 Other available highlighters are `wilder#python_pcre2_highlighter()` and
 `wilder#python_cpsm_highlighter()` which needs `cpsm` to be installed.
 
+# Example configs
+
+### Basic config (for both Vim and Neovim)
+```vim
+call wilder#enable_cmdline_enter()
+set wildcharm=<Tab>
+cmap <expr> <Tab> wilder#in_context() ? wilder#next() : "\<Tab>"
+cmap <expr> <S-Tab> wilder#in_context() ? wilder#previous() : "\<S-Tab>"
+call wilder#set_option('modes', ['/', '?', ':'])
+
+call wilder#set_option('pipeline', [
+      \   wilder#branch(
+      \     wilder#cmdline_pipeline(),
+      \     wilder#search_pipeline(),
+      \   ),
+      \ ])
+
+call wilder#set_option('renderer', wilder#wildmenu_renderer({
+      \ 'highlighter': wilder#basic_highlighter(),
+      \ }))
+```
+
+### Fuzzy config (for Neovim only)
+```vim
+call wilder#enable_cmdline_enter()
+set wildcharm=<Tab>
+cmap <expr> <Tab> wilder#in_context() ? wilder#next() : "\<Tab>"
+cmap <expr> <S-Tab> wilder#in_context() ? wilder#previous() : "\<S-Tab>"
+call wilder#set_option('modes', ['/', '?', ':'])
+
+call wilder#set_option('pipeline', [
+      \   wilder#branch(
+      \     wilder#cmdline_pipeline({
+      \       'fuzzy': 1,
+      \     }),
+      \     wilder#python_search_pipeline({
+      \       'pattern': 'fuzzy',
+      \     }),
+      \   ),
+      \ ])
+
+let s:highlighters = [
+        \ wilder#pcre2_highlighter(),
+        \ wilder#basic_highlighter(),
+        \ ]
+
+call wilder#set_option('renderer', wilder#renderer_mux({
+      \ ':': wilder#popupmenu_renderer({
+      \   'highlighter': s:highlighters,
+      \ }),
+      \ '/': wilder#wildmenu_renderer({
+      \   'highlighter': s:highlighters,
+      \ }),
+      \ }))
+```
+
+### Advanced config (for Neovim only)
+
+- Requires `fd` from [sharkdp/fd](https://github.com/sharkdp/fd)  (see `:h wilder#python_file_finder_pipeline()` on using other commands)
+- Requires `cpsm` from [nixprime/cpsm](https://github.com/nixprime/cpsm)
+- Requires `fzy-lua-native` from [romgrk/fzy-lua-native](https://github.com/romgrk/fzy-lua-native)
+- Requires `nvim-web-devicons` from [kyazdani42/nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) or
+  `vim-devicons` from [ryanoasis/vim-devicons](https://github.com/ryanoasis/vim-devicons)
+
+```vim
+call wilder#enable_cmdline_enter()
+set wildcharm=<Tab>
+cmap <expr> <Tab> wilder#in_context() ? wilder#next() : "\<Tab>"
+cmap <expr> <S-Tab> wilder#in_context() ? wilder#previous() : "\<S-Tab>"
+call wilder#set_option('modes', ['/', '?', ':'])
+
+call wilder#set_option('pipeline', [
+      \   wilder#branch(
+      \     wilder#python_file_finder_pipeline({
+      \       'file_command': {_, arg -> stridx(arg, '.') != -1 ? ['fd', '-tf', '-H'] : ['fd', '-tf']},
+      \       'dir_command': ['fdfind', '-td'],
+      \       'filters': ['cpsm_filter'],
+      \       'cache_timestamp': {-> 1},
+      \     }),
+      \     wilder#cmdline_pipeline({
+      \       'fuzzy': 1,
+      \       'fuzzy_filter': wilder#python_cpsm_filter(),
+      \       'set_pcre2_pattern': 0,
+      \     }),
+      \     wilder#python_search_pipeline({
+      \       'pattern': wilder#python_fuzzy_pattern({
+      \         'start_at_boundary': 0,
+      \       }),
+      \     }),
+      \   ),
+      \ ])
+
+let s:highlighters = [
+      \ wilder#pcre2_highlighter(),
+      \ wilder#lua_fzy_highlighter(),
+      \ ]
+
+call wilder#set_option('renderer', wilder#renderer_mux({
+      \ ':': wilder#popupmenu_renderer({
+      \   'highlighter': s:highlighters,
+      \   'left': [
+      \     wilder#popupmenu_devicons(),
+      \   ],
+      \   'right': [
+      \     ' ',
+      \     wilder#popupmenu_scrollbar(),
+      \   ],
+      \ }),
+      \ '/': wilder#wildmenu_renderer({
+      \   'highlighter': s:highlighters,
+      \ }),
+      \ }))
+```
+
 # Tips
 
 ### Reducing input latency

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -470,6 +470,18 @@ function! wilder#python_cpsm_filt(ctx, opts, candidates, query) abort
   return wilder#cmdline#python_cpsm_filt(a:ctx, a:opts, a:candidates, a:query)
 endfunction
 
+function! wilder#lua_fzy_filter() abort
+  return {ctx, xs, q -> wilder#lua_fzy_filt(ctx, 0, xs, q)}
+endfunction
+
+function! wilder#lua_fzy_filt(ctx, opts, candidates, query) abort
+  if empty(a:query)
+    return a:candidates
+  endif
+
+  return luaeval('require("wilder").fzy_filter(_A[1], _A[2])', [a:candidates, a:query])
+endfunction
+
 " pipelines
 
 function! wilder#search_pipeline(...) abort

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -413,12 +413,28 @@ function! wilder#filter_fuzzy() abort
   return call('wilder#fuzzy_filter', [])
 endfunction
 
-function! wilder#fuzzy_filter() abort
-  return {ctx, xs, q -> wilder#fuzzy_filt(ctx, {}, xs, q)}
+function! wilder#fuzzy_filter(...) abort
+  if has('nvim')
+    return call('wilder#python_fuzzy_filter', a:000)
+  endif
+
+  return wilder#vim_fuzzy_filter()
 endfunction
 
 function! wilder#fuzzy_filt(ctx, opts, candidates, query) abort
-  return wilder#cmdline#fuzzy_filt(a:ctx, a:candidates, a:query)
+  if has('nvim')
+    return wilder#cmdline#python_fuzzy_filt(a:ctx, a:opts, a:candidates, a:query)
+  endif
+
+  return wilder#cmdline#vim_fuzzy_filt(a:ctx, a:candidates, a:query)
+endfunction
+
+function! wilder#vim_fuzzy_filter() abort
+  return {ctx, xs, q -> wilder#fuzzy_filt(ctx, {}, xs, q)}
+endfunction
+
+function! wilder#vim_fuzzy_filt(ctx, opts, candidates, query) abort
+  return wilder#cmdline#vim_fuzzy_filt(a:ctx, a:candidates, a:query)
 endfunction
 
 " DEPRECATED: use wilder#python_fuzzy_filter()

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -843,6 +843,29 @@ function! wilder#draw_devicons(ctx, x, data) abort
   return WebDevIconsGetFileTypeSymbol(a:x, l:is_dir) . ' ' . a:x
 endfunction
 
+function! wilder#devicons_get_icon_from_vim_devicons()
+  return wilder#renderer#popupmenu_column#devicons#get_icon_from_vim_devicons()
+endfunction
+
+function! wilder#devicons_get_icon_from_nerdfont_vim()
+  return wilder#renderer#popupmenu_column#devicons#get_icon_from_nerdfont_vim()
+endfunction
+
+function! wilder#devicons_get_icon_from_nvim_web_devicons(...)
+  let l:opts = a:0 ? a:1 : {}
+  return wilder#renderer#popupmenu_column#devicons#get_icon_from_nvim_web_devicons(l:opts)
+endfunction
+
+function! wilder#devicons_get_hl_from_glyph_palette_vim(...)
+  let l:opts = a:0 ? a:1 : {}
+  return wilder#renderer#popupmenu_column#devicons#get_hl_from_glyph_palette_vim(l:opts)
+endfunction
+
+function! wilder#devicons_get_hl_from_nvim_web_devicons(...)
+  let l:opts = a:0 ? a:1 : {}
+  return wilder#renderer#popupmenu_column#devicons#get_hl_from_nvim_web_devicons(l:opts)
+endfunction
+
 function! s:extract_keys(obj, ...)
   let l:res = {}
 

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -879,9 +879,13 @@ function! wilder#cmdline#substitute_pipeline(opts) abort
         \ wilder#check({-> getcmdtype() ==# ':'}),
         \ {_, x -> wilder#cmdline#parse(x)},
         \ wilder#check({_, res -> wilder#cmdline#is_substitute_command(res.cmd)}),
-        \ {_, res -> len(res.substitute_args) <= 2 ? res : l:hide_in_replace ? v:true : v:false},
+        \ {_, res -> res.cmd ==# 'global' || res.cmd ==# 'vglobal' || len(res.substitute_args) <= 2 ?
+        \   res :
+        \   l:hide_in_replace ? v:true : v:false},
         \ wilder#subpipeline({ctx, res -> [
-        \   {_, res -> res.substitute_args[1]},
+        \   {_, res -> res.cmd ==# 'global' || res.cmd ==# 'vglobal' ?
+        \     res.arg :
+        \     res.substitute_args[1]},
         \ ] + l:search_pipeline + [
         \   wilder#result({
         \     'data': {

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -250,7 +250,7 @@ function! wilder#cmdline#prepare_file_completion(ctx, res, fuzzy)
   return l:res
 endfunction
 
-function! wilder#cmdline#fuzzy_filt(ctx, candidates, query) abort
+function! wilder#cmdline#vim_fuzzy_filt(ctx, candidates, query) abort
   if empty(a:query)
     return a:candidates
   endif
@@ -1106,7 +1106,7 @@ function! wilder#cmdline#getcompletion_pipeline(opts) abort
     elseif l:use_python
       let l:Filter = wilder#python_fuzzy_filter()
     else
-      let l:Filter = wilder#fuzzy_filter()
+      let l:Filter = wilder#vim_fuzzy_filter()
     endif
   endif
 

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -494,6 +494,8 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
     return getcompletion(a:res.cmdline[a:res.subcommand_start :], 'cscope')
   elseif a:res.expand ==# 'event'
     return getcompletion(l:expand_arg, 'event')
+  elseif a:res.expand ==# 'event_and_augroup'
+    return getcompletion(l:expand_arg, 'event') + getcompletion(l:expand_arg, 'augroup')
   elseif a:res.expand ==# 'expression'
     return getcompletion(l:expand_arg, 'expression')
   elseif a:res.expand ==# 'environment'

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -486,7 +486,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
     return getcompletion(l:expand_arg, 'history')
   elseif a:res.expand ==# 'language'
     return getcompletion(l:expand_arg, 'locale') +
-          \ filter(['ctype', 'messages', 'time'], {_, x -> match(x, l:expand_arg) == 0})
+          \ filter(['ctype', 'messages', 'time'], {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'locale'
     return getcompletion(l:expand_arg, 'locale')
   elseif a:res.expand ==# 'mapping'
@@ -503,7 +503,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
       endfor
 
       if l:expand_arg[0] ==# '<'
-        call filter(l:result, {_, x -> match(x, l:expand_arg) == 0})
+        call filter(l:result, {_, x -> s:is_prefix(x, l:expand_arg)})
       endif
     endif
 
@@ -547,7 +547,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
 
     return wilder#uniq_filt(0, 0, l:result)
   elseif a:res.expand ==# 'mapclear'
-    return match('<buffer>', l:expand_arg) == 0 ? ['<buffer>'] : []
+    return s:is_prefix('<buffer>', l:expand_arg) ? ['<buffer>'] : []
   elseif a:res.expand ==# 'menu'
     if !has_key(a:res, 'menu_arg')
       return []
@@ -559,7 +559,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
     return getcompletion(l:expand_arg, 'option')
   elseif a:res.expand ==# 'option_bool'
     return filter(wilder#cmdline#set#get_bool_options(),
-          \ {_, x -> match(x, l:expand_arg == 0)})
+          \ {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'option_old'
     let l:old_option = eval('&' . a:res.option)
     return [type(l:old_option) is v:t_string ? l:old_option : string(l:old_option)]
@@ -567,7 +567,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
     return getcompletion(l:expand_arg, 'packadd')
   elseif a:res.expand ==# 'profile'
     return filter(['continue', 'dump', 'file', 'func', 'pause', 'start'],
-          \ {_, x -> match(x, l:expand_arg) == 0})
+          \ {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'ownsyntax'
     return getcompletion(l:expand_arg, 'syntax')
   elseif a:res.expand ==# 'shellcmd'
@@ -586,10 +586,10 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
     return map(l:functions, {_, x -> x[-1 :] ==# ')' ? x[: -3] : x[: -2]})
   elseif a:res.expand ==# 'user_addr_type'
     return filter(['arguments', 'buffers', 'lines', 'loaded_buffers',
-          \ 'quickfix', 'tabs', 'windows'], {_, x -> match(x, l:expand_arg) == 0})
+          \ 'quickfix', 'tabs', 'windows'], {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'user_cmd_flags'
     return filter(['addr', 'bar', 'buffer', 'complete', 'count',
-          \ 'nargs', 'range', 'register'], {_, x -> match(x, l:expand_arg) == 0})
+          \ 'nargs', 'range', 'register'], {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'user_complete'
     return filter(['arglist', 'augroup', 'behave', 'buffer', 'checkhealth',
           \ 'color', 'command', 'compiler', 'cscope', 'custom',
@@ -598,7 +598,7 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
           \ 'highlight', 'history', 'locale', 'mapclear', 'mapping',
           \ 'menu', 'messages', 'option', 'packadd', 'shellcmd',
           \ 'sign', 'syntax', 'syntime', 'tag', 'tag_listfiles',
-          \ 'user', 'var'], {_, x -> match(x, l:expand_arg) == 0})
+          \ 'user', 'var'], {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'user_nargs'
     if empty(l:expand_arg)
       return ['*', '+', '0', '1', '?']
@@ -1219,4 +1219,16 @@ function! s:set_query(data) abort
   let l:match_arg = get(l:data, 'cmdline.match_arg', '')
 
   return extend(a:data, {'query': l:match_arg})
+endfunction
+
+function! s:is_prefix(str, q) abort
+  if empty(a:q)
+    return 1
+  endif
+
+  if len(a:q) > len(a:str)
+    return 0
+  endif
+
+  return a:str[0 : len(a:q) - 1] ==# a:q
 endfunction

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -46,13 +46,10 @@ endfunction
 function! s:prepare_fuzzy_completion(ctx, res, use_python) abort
   " For non-python completion, a maximum of 300 help tags are returned, so
   " getting all the candidates and filtering will miss out on a lot of matches
-  if a:res.expand ==# 'help'
-    if !a:use_python
-      return a:res
-    endif
   " If argument is empty, don't fuzzy match except for expanding 'help', where
   " the default argument is 'help'
-  elseif a:res.pos == len(a:res.cmdline)
+  if (a:res.expand ==# 'help' && !a:use_python) ||
+        \ a:res.pos == len(a:res.cmdline)
     return a:res
   endif
 
@@ -513,6 +510,9 @@ function! wilder#cmdline#getcompletion(ctx, res) abort
           \ filter(['ctype', 'messages', 'time'], {_, x -> s:is_prefix(x, l:expand_arg)})
   elseif a:res.expand ==# 'locale'
     return getcompletion(l:expand_arg, 'locale')
+  elseif a:res.expand ==# 'lua'
+    " Lua completion not supported
+    return []
   elseif a:res.expand ==# 'mapping'
     let l:map_args = get(a:res, 'map_args', {})
 
@@ -1156,6 +1156,7 @@ function! wilder#cmdline#getcompletion_pipeline(opts) abort
   " └--> completion_pipeline
   return [
         \ wilder#branch(
+        \   [{_, res -> res.expand ==# 'lua' ? v:true : v:false}],
         \   l:file_completion_subpipeline,
         \   l:completion_subpipeline,
         \ ),

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -62,8 +62,7 @@ function! s:prepare_fuzzy_completion(ctx, res, use_python) abort
     let a:res.match_arg = a:res.expand_arg[2 :]
     let a:res.expand_arg = a:res.expand_arg[0: 1]
 
-  " For tag-regexp, use the whole argument as expand_arg as s:getcompletion
-  " will use expand_arg as the pattern for match()
+  " For tag-regexp, keep the argument and don't do fuzzy matching
   elseif a:res.expand ==# 'tags' && a:res.expand_arg[0] ==# '/'
     let a:res.fuzzy_char = ''
     let a:res.match_arg = ''

--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -1040,13 +1040,13 @@ function! s:file_finder(ctx, opts, res) abort
     if has_key(a:opts, 'file_command')
       let l:Command = a:opts['file_command']
     else
-      let l:Command = ['find', '.', '-type', 'f', '-printf', '%P\\n']
+      let l:Command = ['find', '.', '-type', 'f', '-printf', '%P\n']
     endif
   else
     if has_key(a:opts, 'dir_command')
       let l:Command = a:opts['dir_command']
     else
-      let l:Command = ['find', '.', '-type', 'd', '-printf', '%P\\n']
+      let l:Command = ['find', '.', '-type', 'd', '-printf', '%P\n']
     endif
   endif
 

--- a/autoload/wilder/cmdline/main.vim
+++ b/autoload/wilder/cmdline/main.vim
@@ -661,6 +661,9 @@ function! wilder#cmdline#main#do(ctx) abort
   elseif a:ctx.cmd ==# 'argdelete'
     let a:ctx.expand = 'arglist'
     return
+  elseif a:ctx.cmd ==# 'lua'
+    let a:ctx.expand = 'lua'
+    return
   endif
 endfunction
 

--- a/autoload/wilder/cmdline/main.vim
+++ b/autoload/wilder/cmdline/main.vim
@@ -533,15 +533,12 @@ function! wilder#cmdline#main#do(ctx) abort
         \ a:ctx.cmd ==# 'ptag' ||
         \ a:ctx.cmd ==# 'ltag' ||
         \ a:ctx.cmd ==# 'tselect' ||
-        \ a:ctx.cmd ==# 'stelect' ||
+        \ a:ctx.cmd ==# 'stselect' ||
         \ a:ctx.cmd ==# 'tjump' ||
         \ a:ctx.cmd ==# 'stjump' ||
+        \ a:ctx.cmd ==# 'ptselect' ||
         \ a:ctx.cmd ==# 'ptjump'
-    if &wildoptions =~# 'tagfile'
-      let a:ctx.expand = 'tags_listfiles'
-    else
-      let a:ctx.expand = 'tags'
-    endif
+    let a:ctx.expand = 'tags'
     return
   elseif a:ctx.cmd ==# 'augroup'
     let a:ctx.expand = 'augroup'

--- a/autoload/wilder/cmdline/set.vim
+++ b/autoload/wilder/cmdline/set.vim
@@ -1,5 +1,5 @@
 function! wilder#cmdline#set#get_bool_options() abort
-  return s:bool_options_list
+  return copy(s:bool_options_list)
 endfunction
 
 function! wilder#cmdline#set#do(ctx) abort

--- a/autoload/wilder/highlighter.vim
+++ b/autoload/wilder/highlighter.vim
@@ -163,3 +163,36 @@ function! wilder#highlighter#lua_fzy_highlight(ctx, opts, x, data)
         \ 'require("wilder").fzy_highlight(_A[1], _A[2])',
         \ [a:data.query, a:x])
 endfunction
+
+function! wilder#highlighter#tag_regexp_highlighter()
+  return funcref('wilder#highlighter#tag_regexp_highlight')
+endfunction
+
+function! wilder#highlighter#tag_regexp_highlight(ctx, x, data)
+  let l:expand = get(a:data, 'cmdline.expand', '')
+
+  if l:expand !=# 'tags'
+    return 0
+  endif
+
+  let l:arg = get(a:data, 'cmdline.arg', '')
+
+  if l:arg[0] !=# '/'
+    return 0
+  endif
+
+  let l:pattern = l:arg[1:]
+
+  let l:start = match(a:x, l:pattern)
+  if l:start == -1
+    return []
+  endif
+
+  let l:matches = matchlist(a:x, l:arg[1:])
+  if empty(l:matches)
+    return []
+  endif
+
+  let l:len = strlen(l:matches[0])
+  return [[l:start, l:len]]
+endfunction

--- a/autoload/wilder/renderer/popupmenu_column/devicons.vim
+++ b/autoload/wilder/renderer/popupmenu_column/devicons.vim
@@ -3,14 +3,17 @@ function! wilder#renderer#popupmenu_column#devicons#make(opts) abort
   let l:state = {
         \ 'session_id': -1,
         \ 'cache': wilder#cache#cache(),
+        \ 'created_hls': {},
         \ 'left_padding': repeat(' ', l:padding[0]),
         \ 'right_padding': repeat(' ', l:padding[1]),
         \ }
 
-  if !has_key(a:opts, 'get_icon')
-    let l:state.get_icon = 'WebDevIconsGetFileTypeSymbol'
-  else
+  if has_key(a:opts, 'get_icon')
     let l:state.get_icon = a:opts.get_icon
+  endif
+
+  if has_key(a:opts, 'get_hl')
+    let l:state.get_hl = a:opts.get_hl
   endif
 
   return {ctx, result -> s:devicons(l:state, ctx, result)}
@@ -30,6 +33,7 @@ function! s:devicons(state, ctx, result) abort
   let l:session_id = a:ctx.session_id
   if a:state.session_id != l:session_id
     call a:state.cache.clear()
+    let a:state.created_hls = {}
     let a:state.session_id = l:session_id
   endif
 
@@ -43,9 +47,16 @@ function! s:devicons(state, ctx, result) abort
 
   let l:icons = repeat([0], l:end - l:start + 1)
 
-  let l:Get_icon = a:state.get_icon
-  if type(l:Get_icon) is v:t_string
-    let l:Get_icon = function(l:Get_icon)
+  if !has_key(a:state, 'get_icon')
+    let a:state.get_icon = s:get_icon_func()
+  endif
+
+  if a:state.get_icon is v:null
+    return []
+  endif
+
+  if !has_key(a:state, 'get_hl')
+    let a:state.get_hl = s:get_hl_func()
   endif
 
   let l:i = l:start
@@ -63,9 +74,24 @@ function! s:devicons(state, ctx, result) abort
 
     let l:is_dir = l:x[-1:] ==# l:slash || l:x[-1:] ==# '/'
 
-    let l:icon = l:Get_icon(l:x, l:is_dir)
+    let l:icon = a:state.get_icon(a:ctx, l:x, l:is_dir)
 
-    let l:chunks = [[a:state.left_padding . l:icon . a:state.right_padding]]
+    if a:state.get_hl is v:null
+      let l:chunks = [[a:state.left_padding . l:icon . a:state.right_padding]]
+    else
+      let l:hl = a:state.get_hl(a:ctx, l:x, l:is_dir, l:icon)
+
+      if !has_key(a:state.created_hls, l:hl)
+        let l:guifg = s:get_guifg(l:hl)
+        let l:default_hl = s:make_temp_hl(l:hl, a:ctx.highlights['default'], l:guifg, 0)
+        let l:selected_hl = s:make_temp_hl(l:hl, a:ctx.highlights['selected'], l:guifg, 1)
+        let a:state.created_hls[l:hl] = [l:default_hl, l:selected_hl]
+      endif
+
+      let [l:default_hl, l:selected_hl] = a:state.created_hls[l:hl]
+      let l:chunks = [[a:state.left_padding], [l:icon, l:default_hl, l:selected_hl], [a:state.right_padding]]
+    endif
+
     call a:state.cache.set(l:x, l:chunks)
 
     let l:icons[l:index] = l:chunks
@@ -76,16 +102,126 @@ function! s:devicons(state, ctx, result) abort
   return l:icons
 endfunction
 
-function! s:get_guibg(hl) abort
+function! s:get_guifg(hl) abort
   let l:gui_colors = wilder#highlight#get_hl(a:hl)[2]
 
   return get(l:gui_colors, 'reverse', 0) || get(l:gui_colors, 'standout', 0) ?
-        \ l:gui_colors.foreground :
-        \ l:gui_colors.background
+        \ get(l:gui_colors, 'background', 'NONE') :
+        \ get(l:gui_colors, 'foreground', 'NONE')
 endfunction
 
-function! s:make_temp_hl(hl, guibg, selected) abort
+function! s:make_temp_hl(name, hl, guifg, selected) abort
   let l:name = a:selected ? 'WilderDeviconsSelected_' : 'WilderDevicons_'
-  return wilder#make_temp_hl(l:name . a:hl, a:hl,
-        \ [{}, {}, {'background': a:guibg}])
+  let l:name .= a:name
+
+  let l:gui_colors = wilder#highlight#get_hl(a:hl)[2]
+  let l:reverse = get(l:gui_colors, 'reverse', 0) || get(l:gui_colors, 'standout', 0)
+
+  return wilder#make_temp_hl(l:name, a:hl,
+        \ [{}, {}, l:reverse ? {'background': a:guifg} : {'foreground': a:guifg}])
+endfunction
+
+function! s:get_icon_func()
+  if has('nvim-0.5')
+    try
+      call luaeval("require'nvim-web-devicons'")
+      return wilder#devicons_get_icon_from_nvim_web_devicons()
+    catch
+    endtry
+  endif
+
+  if exists('*WebDevIconsGetFileTypeSymbol')
+    return wilder#devicons_get_icon_from_vim_devicons()
+  endif
+
+  try
+    call nerdfont#find('')
+    return wilder#devicons_get_icon_from_nerdfont_vim()
+  catch
+  endtry
+
+  return v:null
+endfunction
+
+function! s:get_hl_func()
+  if has('nvim-0.5')
+    try
+      call luaeval("require'nvim-web-devicons'")
+      return wilder#devicons_get_hl_from_nvim_web_devicons()
+    catch
+    endtry
+  endif
+
+  if exists('g:loaded_glyph_palette')
+    return wilder#devicons_get_hl_from_glyph_palette_vim()
+  endif
+
+  return v:null
+endfunction
+
+function! wilder#renderer#popupmenu_column#devicons#get_icon_from_vim_devicons()
+  return {ctx, name, is_dir -> WebDevIconsGetFileTypeSymbol(name, is_dir)}
+endfunction
+
+function! wilder#renderer#popupmenu_column#devicons#get_icon_from_nerdfont_vim()
+  return {ctx, name -> nerdfont#find(name)}
+endfunction
+
+function! wilder#renderer#popupmenu_column#devicons#get_icon_from_nvim_web_devicons(opts)
+  return {ctx, name, is_dir -> s:get_icon_from_nvim_web_devicons(a:opts, name, is_dir)}
+endfunction
+
+function! s:get_icon_from_nvim_web_devicons(opts, name, is_dir)
+  if a:is_dir
+    return get(a:opts, 'dir_icon', '')
+  endif
+
+  let l:ext = fnamemodify(a:name, ':e')
+  let l:icon = luaeval("require'nvim-web-devicons'.get_icon")(l:ext)
+
+  return l:icon is v:null ? get(a:opts, 'default_icon', '') : l:icon
+endfunction
+
+function! wilder#renderer#popupmenu_column#devicons#get_hl_from_nvim_web_devicons(opts)
+  if !luaeval("require'nvim-web-devicons'.has_loaded()")
+    call luaeval("require'nvim-web-devicons'.setup()")
+  endif
+
+  return {ctx, name, is_dir, icon -> s:hl_from_nvim_web_devicons(a:opts, name, is_dir)}
+endfunction
+
+function! s:hl_from_nvim_web_devicons(opts, name, is_dir)
+  if a:is_dir
+    return get(a:opts, 'dir_hl', 'Directory')
+  endif
+
+  let l:hl = 'DevIcon' . fnamemodify(a:name, ':e')
+
+  return hlexists(l:hl) ? l:hl : get(a:opts, 'default_hl', 'Normal')
+endfunction
+
+function! wilder#renderer#popupmenu_column#devicons#get_hl_from_glyph_palette_vim(opts)
+  return {ctx, name, is_dir, icon -> s:get_hl_from_glyph_palette_vim(a:opts, ctx, icon)}
+endfunction
+
+let s:glyph_hls = {}
+let s:glyph_hls_session_id = -1
+
+function! s:get_hl_from_glyph_palette_vim(opts, ctx, icon)
+  if a:ctx.session_id > s:glyph_hls_session_id
+    let s:glyph_hls_session_id = a:ctx.session_id
+
+    let s:glyph_hls = {}
+    for l:key in keys(g:glyph_palette#palette)
+      for l:icon in g:glyph_palette#palette[l:key]
+        let s:glyph_hls[l:icon] = l:key
+      endfor
+    endfor
+  endif
+
+  if has_key(s:glyph_hls, a:icon)
+    return s:glyph_hls[a:icon]
+  endif
+
+  return get(a:opts, 'default_hl', 'Normal')
 endfunction

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -927,6 +927,11 @@ wilder#python_file_finder_pipeline([{options}])
 
             For performance, using `cpsm` with ['cpsm_filter'] is recommended.
 
+            Note: The arguments are different from the `fuzzy_filter` option
+            in other pipelines such as |wilder#cmdline_pipeline()|. This is
+            for performance reasons as it allows the filtering to be done in
+            Python returning the results.
+
             The available filters are:
             `fuzzy_filter`
             Filters the list with |wilder#python_fuzzy_filter()|.
@@ -2815,21 +2820,21 @@ Minimal Configuration~
     call wilder#set_option('modes', ['/', '?', ':'])
 <
 
-Pipelines (Neovim only)~
+Fuzzy pipelines (Neovim only)~
 >
     " add minimal configuration
     call wilder#set_option('pipeline', [
           \   wilder#branch(
           \     [
           \       wilder#check({_, x -> empty(x)}),
-          \       wilder#history(100),
+          \       wilder#history(),
           \     ],
           \     wilder#cmdline_pipeline({
           \       'language': 'python',
           \       'fuzzy': 1,
           \     }),
           \     wilder#python_search_pipeline({
-          \       'fuzzy': 1,
+          \       'pattern': 'fuzzy',
           \     }),
           \   ),
           \ ])
@@ -2843,6 +2848,15 @@ Airline/Lightline Theme for Wildmenu Renderer~
           \   'highlighter': wilder#basic_highlighter(),
           \   'separator': ' · ',
           \ })))
+<
+
+Use Popupmenu for : and Wildmenu for /~
+>
+    " use wilder#wildmenu_lightline_theme() for Lightline
+    wilder#set_option('renderer, wilder#renderer_mux({
+          \ ':': wilder#popupmenu_renderer(),
+          \ '/': wilder#wildmenu_renderer(),
+          \ })
 <
 
 ==============================================================================

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -724,10 +724,9 @@ wilder#cmdline_pipeline([{options}])
             have to start with the first character of the query. If 2, the
             candidates do not have to start with the first character.
 
-            Note: Fuzzy matching does not work in some cases, e.g. when
-            getting |help| completions, when completing filenames with
-            |wildcards| or user-defined command completions
-            |:command-completion|.
+            Note: Fuzzy matching does not work in some cases, e.g.  when
+            completing filenames with |wildcards| or user-defined command
+            completions |:command-completion|.
 
             Note: When set to 2, `shellcmd` candidates will still start with
             the first character of the query due to performance reasons.

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -2268,8 +2268,10 @@ wilder#python_cpsm_filt({ctx}, {opts}, {candidates}, {query})
                                     Async~
                                     cpsm plugin required~
             Takes a list of candidates and fuzzily filters and sorts the
-            candidates using `cpsm`. The `cpsm` Vim plugin is required and can
-            be found at https://github.com/nixprime/cpsm.
+            candidates using `cpsm`.
+
+            The `cpsm` Vim plugin is required and can be found at
+            https://github.com/nixprime/cpsm.
 
             {opts} can contain the following keys:
             `cpsm_path`
@@ -2284,13 +2286,33 @@ wilder#python_cpsm_filter([{cpsm_path}])
                                     Neovim only~
                                     cpsm plugin required~
             Returns a fuzzy filter that filters and sorts the candidates using
-            |wilder#python_cpsm_filt()|.
+            |wilder#python_cpsm_filt()|. Can be used as the `fuzzy_filter`
+            option in |wilder#cmdline_pipeline()|.
 
             The {cpsm_path} argument is passed to |wilder#python_cpsm_filt()|
             as an option.
 
             {cpsm_path} can be provided to set the path for `cpsm_py.so`. It
             is inferred by Neovim otherwise.
+
+                                    *wilder#lua_fzy_filt()*
+wilder#lua_fzy_filt({ctx}, {opts}, {candidates}, {query})
+                                    Neovim only~
+                                    fzy-lua-native plugin required~
+            Takes a list of candidates and fuzzily filters and sorts the
+            candidates using `fzy-lua-native`.
+
+            The `fzy-lua-native` plugin can be found at
+            https://github.com/romgrk/fzy-lua-native.
+
+            {opts} is ignored.
+
+wilder#lua_fzy_filter()             *wilder#lua_fzy_filter()*
+                                    Neovim only~
+                                    fzy-lua-native plugin required~
+            Returns a fuzzy filter that filters and sorts the candidates using
+            |wilder#lua_fzy_filt()|. Can be used as the `fuzzy_filter` option
+            in |wilder#cmdline_pipeline()|.
 
                                     *wilder#lexical_sort()*
 wilder#lexical_sort({ctx}, {opts}, {candidates}[, {query}])

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1831,15 +1831,34 @@ wilder#popupmenu_devicons([{options}])
             {options} is a dictionary with keys:
             `get_icon`
             Optional~
-            A function name or a function. The function should take 2
-            arguments {file_name} and {is_dir} and return the icon to use.
-
-            To use `nerdfont.vim`, set this to {name -> nerdfont#find(name)}.
+            A function which takes {ctx}, {file_name} and {is_dir} as
+            arguments and return the icon to use.
+            {ctx} contains a single key `session_id` (see
+            |wilder-pipeline-context| for the meaning of `session_id`).
 
             Note: The icons returned should all be of the same
             |strdisplaywidth()|.
 
-            Default: 'WebDevIconsGetFileTypeSymbol'
+            Default:
+            |wilder#devicons_get_icon_from_nvim_web_devicons()|,
+            |wilder#devicons_get_icon_from_vim_devicons()| or
+            |wilder#devicons_get_icon_from_nerdfont_vim()|
+            depending on whether their respective dependencies are installed.
+
+            `get_hl`
+            Optional~
+            A function which takes {ctx}, {file_name}, {is_dir} and {icon} as
+            arguments and return the highlight to use.
+            {ctx} contains a single key `session_id` (see
+            |wilder-pipeline-context| for the meaning of `session_id`).
+            {icon} is the icon returned from `get_icon`.
+
+            Setting this to v:null turns off highlighting.
+
+            Default:
+            |wilder#devicons_get_hl_from_nvim_web_devicons()| or
+            |wilder#devicons_get_hl_from_glyph_palette_vim()|
+            depending on whether their respective dependencies are installed.
 
             `padding`
             Optional~
@@ -2557,6 +2576,88 @@ wilder#renderer_mux({args})         *wilder#renderer_mux()*
                   \ })
 <
 
+                           *wilder#devicons_get_icon_from_nvim_web_devicons()*
+                           Neovim 0.5+ only~
+                           nvim-web-devicons plugin required~
+wilder#devicons_get_icon_from_nvim_web_devicons([{options}])
+            Returns a function for the `get_icon` option in
+            |wilder#popupmenu_devicons()|.
+
+            The `nvim-web-devicons` plugin can be found at
+            https://github.com/kyazdani42/nvim-web-devicons.
+
+            {options} is a dictionary with keys:
+            `dir_icon`
+            Optional~
+            The icon for directories since `nvim-web-devicons` does not
+            support directories.
+
+            Default: ''
+
+            `default_icon`
+            Optional~
+            The default icon when there is no match from `nvim-web-devicons`.
+
+            Default: ''
+
+                               *wilder#devicons_get_icon_from_vim_devicons()*
+                               vim-devicons plugin required~
+wilder#devicons_get_icon_from_vim_devicons()
+            Returns a function for `get_icon` option in
+            |wilder#popupmenu_devicons()|.
+
+            The `vim-devicons` plugin can be found at
+            https://github.com/ryanoasis/vim-devicons.
+
+                               *wilder#devicons_get_icon_from_nerdfont_vim()*
+                               nerdfont.vim plugin required~
+wilder#devicons_get_icon_from_nerdfont_vim()
+            Returns a function for the `get_icon` option in
+            |wilder#popupmenu_devicons()|.
+
+            The `nerdfont.vim` plugin can be found at
+            https://github.com/lambdalisue/nerdfont.vim.
+
+                           *wilder#devicons_get_hl_from_nvim_web_devicons()*
+                           Neovim 0.5+ only~
+                           nvim-web-devicons plugin required~
+wilder#devicons_get_hl_from_nvim_web_devicons([{options}])
+            Returns a function for the `get_hl` option in
+            |wilder#popupmenu_devicons()|.
+
+            The `nvim-web-devicons` plugin can be found at
+            https://github.com/kyazdani42/nvim-web-devicons.
+
+            {options} is a dictionary with keys:
+            `dir_hl`
+            Optional~
+            The highlight used for directories.
+
+            Default: 'Directory'
+
+            `default_hl`
+            Optional~
+            The highlight used when there is no match from
+            `nvim-web-devicons`.
+
+            Default: 'Normal'
+
+                           *wilder#devicons_get_hl_from_glyph_palette_vim()*
+                           glyph-palette.vim plugin required~
+wilder#devicons_get_hl_from_glyph_palette_vim([{options}])
+            Returns a function for the `get_hl` option in
+            |wilder#popupmenu_devicons()|.
+
+            The `glyph-palette.vim` plugin can be found at
+            https://github.com/lambdalisue/glyph-palette.vim.
+
+            {options} is a dictionary with keys:
+            `default_hl`
+            Optional~
+            The highlight used when there is no match from
+            `glyph-palette.vim`.
+
+            Default: 'Normal'
 
 ==============================================================================
 7. Deprecated                       *wilder-deprecated*

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -758,7 +758,7 @@ wilder#cmdline_pipeline([{options}])
             endfunction
 <
             Default: |wilder#python_fuzzy_filter()| if `language` is 'python'
-                     |wilder#fuzzy_filter()| otherwise
+                     |wilder#vim_fuzzy_filter()| otherwise
 
             `hide_in_substitute`
             When true, hides wilder when in a |:substitute| command.
@@ -2189,6 +2189,19 @@ wilder#fuzzy_filt({ctx}, {opts}, {candidates}, {query})
             Takes a list of candidates and fuzzily filters and sorts the
             candidates.
 
+            Uses |wilder#python_fuzzy_filt()| if has('nvim'). Otherwise uses
+            |wilder#vim_fuzzy_filt()|.
+
+wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
+            Returns a fuzzy filter that filters and sorts the candidates using
+            |wilder#fuzzy_filt()|. Can be used as the `fuzzy_filter` option in
+            |wilder#cmdline_pipeline()|.
+
+                                    *wilder#vim_fuzzy_filt()*
+wilder#vim_fuzzy_filt({ctx}, {opts}, {candidates}, {query})
+            Takes a list of candidates and fuzzily filters and sorts the
+            candidates.
+
             A {candidate} is matched if it contains all the characters in
             {query} and in the same order.
 
@@ -2197,10 +2210,10 @@ wilder#fuzzy_filt({ctx}, {opts}, {candidates}, {query})
 
             Options contains no keys.
 
-wilder#fuzzy_filter()               *wilder#fuzzy_filter()*
+wilder#vim_fuzzy_filter()           *wilder#vim_fuzzy_filter()*
             Returns a fuzzy filter that filters and sorts the candidates using
-            |wilder#fuzzy_filt()|. Can be used as the `fuzzy_filter` option in
-            |wilder#cmdline_pipeline()|.
+            |wilder#vim_fuzzy_filt()|. Can be used as the `fuzzy_filter`
+            option in |wilder#cmdline_pipeline()|.
 
                                     *wilder#python_fuzzy_filt()*
 wilder#python_fuzzy_filt({ctx}, {opts}, {candidates}, {query})

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -835,6 +835,10 @@ wilder#python_file_finder_pipeline([{options}])
             To use `ripgrep`, set to this option to ['rg', '--files'].
             To use `fd`, set to this option to ['fd', '-tf'].
 
+            To dynamically search hidden directories depending on the
+            argument, use (for `fd`)
+            {_, arg -> arg[0] ==# '.' ? ['fd', '-tf', -H'] : ['fd', '-tf']}
+
             Default: ['find', '.', '-type', 'f', '-printf', '%P\n']
 
             `dir_command`

--- a/lua/wilder.lua
+++ b/lua/wilder.lua
@@ -1,3 +1,24 @@
+local function fzy_filter(xs, q)
+  local scores = require'fzy-lua-native'.filter(q, xs, false)
+  result = {}
+
+  table.sort(scores, function(a, b)
+    if b[3] == nil then
+      return true
+    elseif a[3] == nil then
+      return false
+    end
+
+    return a[3] > b[3]
+  end)
+
+  for i = 1, #scores do
+    table.insert(result, scores[i][1])
+  end
+
+  return result
+end
+
 local cached_pattern = nil
 local cached_re = nil
 
@@ -90,6 +111,7 @@ local function fzy_highlight(needle, haystack)
 end
 
 return {
+  fzy_filter = fzy_filter,
   fzy_highlight = fzy_highlight,
   pcre2_highlight = pcre2_highlight,
 }

--- a/rplugin/python3/wilder/__init__.py
+++ b/rplugin/python3/wilder/__init__.py
@@ -478,7 +478,7 @@ class Wilder(object):
         return os.path.basename(f)
 
     @neovim.function('_wilder_python_get_help_tags', sync=False, allow_nested=True)
-    def _get_get_help_tags(self, args):
+    def _get_help_tags(self, args):
         self.run_in_background(self.get_help_tags_handler, args)
 
     def get_help_tags_handler(self, event, ctx, rtp, helplang):


### PR DESCRIPTION
### New features
- `wilder#cmdline_pipeline()` now supports fuzzy `tag` completion
- `wilder#popupmenu_devicons()` now supports highlighting icons with the `get_hl` option
- Added `wilder#lua_fzy_filter()`

### Fixes
- Fixed non-fuzzy cmdline completion not matching from start of candidate
- Fixed `global` and `vglobal` cmdline completion
- Fixed `autocmd` cmdline completion
- `lua` cmdline completion now returns `v:true`
- Fixed default `file_cmd` and `dir_cmd` options for `wilder#python_file_finder()`

### Breaking changes
- `wilder#fuzzy_filter()` renamed to `wilder#vim_fuzzy_filter()`. `wilder#fuzzy_filter()` now returns `wilder#vim_fuzzy_filter()` and `wilder#python_fuzzy_filter()` depending on `has('nvim')`
- The `get_icon` option for `wilder#popupmenu_devicons()` now takes `{ctx}, {file_name}, {is_dir}` instead of just `{file_name}, {is_dir}`