### PR TITLE
Add auto_select parameter for accept_completion

### DIFF
--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -75,8 +75,8 @@ function! wilder#can_accept_completion()
 endfunction
 
 function! wilder#accept_completion(...)
-  let auto_select = get(a:, 1, 1)
-  return wilder#main#accept_completion(auto_select)
+  let l:auto_select = get(a:, 1, 1)
+  return wilder#main#accept_completion(l:auto_select)
 endfunction
 
 function! wilder#start_from_normal_mode()

--- a/autoload/wilder.vim
+++ b/autoload/wilder.vim
@@ -74,8 +74,9 @@ function! wilder#can_accept_completion()
   return wilder#main#can_accept_completion()
 endfunction
 
-function! wilder#accept_completion()
-  return wilder#main#accept_completion()
+function! wilder#accept_completion(...)
+  let auto_select = get(a:, 1, 1)
+  return wilder#main#accept_completion(auto_select)
 endfunction
 
 function! wilder#start_from_normal_mode()

--- a/autoload/wilder/main.vim
+++ b/autoload/wilder/main.vim
@@ -618,7 +618,7 @@ function! wilder#main#can_accept_completion() abort
         \ exists('s:selected') && s:selected >= 0
 endfunction
 
-function! wilder#main#accept_completion() abort
+function! wilder#main#accept_completion(auto_select) abort
   if exists('s:selected') && s:selected >= 0
     let l:cmdline = getcmdline()
 
@@ -635,7 +635,7 @@ function! wilder#main#accept_completion() abort
     let s:selected = -1
     let s:clear_selection = 1
 
-    call s:run_pipeline(l:cmdline, {'auto_select': 1})
+    call s:run_pipeline(l:cmdline, {'auto_select': a:auto_select})
   endif
 
   return "\<Insert>\<Insert>"

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -1969,13 +1969,14 @@ wilder#can_reject_completion()      *wilder#can_reject_completion()*
             Returns true if |wilder#in_context()| is true, and there is a
             completion which can be rejected.
 
-wilder#accept_completion([{auto_select}])          *wilder#accept_completion()*
-            Accepts the current completion. Mainly used when in |menus| in
-            cmdline mode.
+                                    *wilder#accept_completion()*
+wilder#accept_completion([{auto_select}])
+            Accepts the current completion. This replaces the current cmdline
+            with the selected candidate and retrieves candidates for the new
+            cmdline.
 
-            {auto_select} can be provided to control the auto selection
-            behaviour. If 1 (the default) the first item from the selected
-            directory will be added. If 0 no auto selection is made.
+            If {auto_select} is true, the first item from the new candidates
+            will be selected. Defaults to 1.
 
             Example:
 >

--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -745,7 +745,7 @@ wilder#cmdline_pipeline([{options}])
             Optional~
             The function to use when matching candidates in fuzzy completion.
             Takes a {ctx}, {candidates} and {query} and returns the list of
-            filtered candidates. 
+            filtered candidates.
 
             Can return a |wilder-pipeline-thunk|.  Only used if `fuzzy` is
             true.
@@ -1518,7 +1518,7 @@ wilder#wldmnue_next_arrow([{options}])
             The highlight group to use.
 
             Default: None
-             
+
 wilder#wildmenu_index([{options}])  *wilder#wildmenu_index()*
                                     wilder#wildmenu_renderer() item~
             Adds the index of the currently selected candidate and the total
@@ -1969,9 +1969,13 @@ wilder#can_reject_completion()      *wilder#can_reject_completion()*
             Returns true if |wilder#in_context()| is true, and there is a
             completion which can be rejected.
 
-wilder#accept_completion()          *wilder#accept_completion()*
+wilder#accept_completion([{auto_select}])          *wilder#accept_completion()*
             Accepts the current completion. Mainly used when in |menus| in
             cmdline mode.
+
+            {auto_select} can be provided to control the auto selection
+            behaviour. If 1 (the default) the first item from the selected
+            directory will be added. If 0 no auto selection is made.
 
             Example:
 >


### PR DESCRIPTION
Added an optional argument to `accept_completion` to control the auto select behaviour as discussed in #59.

The argument has only been made optional for `wilder#accept_completion` the user facing function. I left the argument to `wilder#main#accept_completion` mandatory but can change it you prefer to keep it optional all the way down.

Side note: I have vim configured to trim white trailing space and inadvertently commited some removal of it that was left around the docs. Hope that is okay. I can of course also undo this.