### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/wilder.txt
+++ b/doc/wilder.txt
@@ -3098,7 +3098,7 @@ wilder#basic_highlighter([{opts}])  *wilder#basic_highlighter()*
 
             `case_sensitive`
             Optional~
-            If true, the matching is case insensitive, and case insensitive
+            If true, the matching is case insensitive, and case sensitive
             otherwise.
 
             Default: 0


### PR DESCRIPTION
Love the plugin, very flexible api and well documented. Spotted a small error while reading through.

I'm assuming this is correct from the context.