### PR TITLE
Do not use file finder with path argument starting with '.'

### DIFF
--- a/autoload/wilder/cmdline.vim
+++ b/autoload/wilder/cmdline.vim
@@ -796,10 +796,13 @@ function wilder#cmdline#should_use_file_finder(res) abort
 
   let l:path = a:res.expand_arg
 
-  " Prevent scanning of filesystem accidentally.
+  " For a path argument for absolute path, current/parent directory,
+  " or hidden files, do not use file finder.
+  " (this may also help prevent scanning of filesystem accidentally)
   if l:path ==# '~' ||
         \ l:path[0] ==# '/' ||
         \ l:path[0] ==# '\' ||
+        \ l:path[0] ==# '.' ||
         \ l:path[0:1] ==# '..'
     return 0
   endif


### PR DESCRIPTION
As discussed in #101, path arguments starting with '.' may refer to
hidden files or files in the current directory, in which case
(fuzzy) file finder would be avoided.