### PR TITLE
Fix popupmenu renderer overlapping with other floating windows

### DIFF
--- a/autoload/wilder/renderer/nvim_api.vim
+++ b/autoload/wilder/renderer/nvim_api.vim
@@ -8,6 +8,7 @@ function! wilder#renderer#nvim_api#() abort
         \ 'ns_id': nvim_create_namespace(''),
         \ 'normal_highlight': 'Normal',
         \ 'winblend': 0,
+        \ 'zindex': 0,
         \ 'window_state': 'hidden',
         \ 'dimensions': -1,
         \ 'firstline': -1,
@@ -52,6 +53,7 @@ function! s:new(opts) dict abort
 
   let self.state.normal_highlight = get(a:opts, 'normal_highlight', 'Normal')
   let self.state.winblend = get(a:opts, 'winblend', 0)
+  let self.state.zindex = get(a:opts, 'zindex', 0)
 endfunction
 
 function! s:new_buf() abort
@@ -86,14 +88,20 @@ function! s:_open_win() dict abort
   " Fix E5555 when re-showing wilder when inccommand is cancelled.
   let l:buf = has('nvim-0.6') ? 0 : self.state.buf
 
-  let self.state.win = nvim_open_win(l:buf, 0, {
+  let l:win_opts = {
         \ 'relative': 'editor',
         \ 'height': 1,
         \ 'width': 1,
         \ 'row': &lines - 1,
         \ 'col': 0,
         \ 'focusable': 0,
-        \ })
+        \ }
+
+  if has('nvim-0.5.1')
+    let l:win_opts.zindex = self.state.zindex
+  endif
+
+  let self.state.win = nvim_open_win(l:buf, 0, l:win_opts)
 
   let self.state.window_state = 'showing'
 

--- a/autoload/wilder/renderer/popupmenu.vim
+++ b/autoload/wilder/renderer/popupmenu.vim
@@ -15,6 +15,7 @@ function! wilder#renderer#popupmenu#(opts) abort
         \ 'highlight_mode': get(a:opts, 'highlight_mode', 'detailed'),
         \ 'left_offset': get(a:opts, 'left_offset', 1),
         \ 'winblend': get(a:opts, 'winblend', 0),
+        \ 'zindex': get(a:opts, 'zindex', 250),
         \ 'top': get(a:opts, 'top', []),
         \ 'bottom': get(a:opts, 'bottom', []),
         \ 'empty_message': get(a:opts, 'empty_message', 0),
@@ -657,6 +658,7 @@ endfunction
 function! s:pre_hook(state, ctx) abort
   call a:state.api.new({
         \ 'normal_highlight': a:state.highlights.default,
+        \ 'zindex': get(a:state, 'zindex', 0),
         \ 'winblend': get(a:state, 'winblend', 0)
         \ })
 

--- a/autoload/wilder/renderer/vim_api.vim
+++ b/autoload/wilder/renderer/vim_api.vim
@@ -46,6 +46,7 @@ function! s:new(opts) dict abort
           \ 'col': 1,
           \ 'fixed': 1,
           \ 'wrap': 0,
+          \ 'zindex': get(a:opts, 'zindex', 0),
           \ 'scrollbar': 0,
           \ 'cursorline': 0,
           \ 'highlight': get(a:opts, 'normal_highlight', 'Normal'),


### PR DESCRIPTION
| Before | After |
| ------- | ------ |
| <img src="https://user-images.githubusercontent.com/920910/139458067-28423511-f5ab-4699-b19e-93803343c36e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/920910/139459923-544c2f2e-cec2-4ad9-a31d-26ef3f0aae75.png" width="300" /> |

According to [the neovim docs](https://neovim.io/doc/user/api.html#nvim_open_win()), the default `zindex` for the cmdline popupmenu is 250.

However, vim docs don't mention anything about the cmdline popupmenu:
```
zindex   Priority for the popup, default 50.  Minimum value is 1, maximum value is 32000.
```

N.B. I use neovim and I haven't tested with vim.