### PR TITLE
Fix 'zindex must be a positive integer' error

### DIFF
--- a/autoload/wilder/renderer/nvim_api.vim
+++ b/autoload/wilder/renderer/nvim_api.vim
@@ -53,7 +53,7 @@ function! s:new(opts) dict abort
 
   let self.state.normal_highlight = get(a:opts, 'normal_highlight', 'Normal')
   let self.state.winblend = get(a:opts, 'winblend', 0)
-  let self.state.zindex = get(a:opts, 'zindex', 0)
+  let self.state.zindex = get(a:opts, 'zindex', v:null)
 endfunction
 
 function! s:new_buf() abort
@@ -97,7 +97,7 @@ function! s:_open_win() dict abort
         \ 'focusable': 0,
         \ }
 
-  if has('nvim-0.5.1')
+  if has('nvim-0.5.1') && self.state.zindex != v:null
     let l:win_opts.zindex = self.state.zindex
   endif
 

--- a/autoload/wilder/renderer/popupmenu.vim
+++ b/autoload/wilder/renderer/popupmenu.vim
@@ -658,7 +658,7 @@ endfunction
 function! s:pre_hook(state, ctx) abort
   call a:state.api.new({
         \ 'normal_highlight': a:state.highlights.default,
-        \ 'zindex': get(a:state, 'zindex', 0),
+        \ 'zindex': get(a:state, 'zindex', v:null),
         \ 'winblend': get(a:state, 'winblend', 0)
         \ })
 

--- a/autoload/wilder/renderer/vim_api.vim
+++ b/autoload/wilder/renderer/vim_api.vim
@@ -41,16 +41,22 @@ function! s:new(opts) dict abort
   endif
 
   if index(popup_list(), self.state.win) == -1
-    let self.state.win = popup_create(self.state.buf, {
+    let l:popup_opts = {
           \ 'line': 1,
           \ 'col': 1,
           \ 'fixed': 1,
           \ 'wrap': 0,
-          \ 'zindex': get(a:opts, 'zindex', 0),
           \ 'scrollbar': 0,
           \ 'cursorline': 0,
           \ 'highlight': get(a:opts, 'normal_highlight', 'Normal'),
-          \ })
+          \ }
+
+    let l:zindex = get(a:opts, 'zindex', v:null)
+    if a:opts.zindex != v:null
+      let l:popup_opts.zindex = l:zindex
+    endif
+
+    let self.state.win = popup_create(self.state.buf, l:popup_opts)
     call popup_hide(self.state.win)
   endif
 endfunction

--- a/autoload/wilder/renderer/wildmenu.vim
+++ b/autoload/wilder/renderer/wildmenu.vim
@@ -9,6 +9,7 @@ function! wilder#renderer#wildmenu#prepare_state(opts) abort
         \ 'separator': wilder#render#to_printable(get(a:opts, 'separator', '  ')),
         \ 'ellipsis': wilder#render#to_printable(get(a:opts, 'ellipsis', '...')),
         \ 'apply_incsearch_fix': get(a:opts, 'apply_incsearch_fix', has('nvim') && !has('nvim-0.5.1')),
+        \ 'zindex': get(a:opts, 'zindex', v:null),
         \
         \ 'page': [-1, -1],
         \ 'columns': -1,

--- a/autoload/wilder/renderer/wildmenu_float_or_popup.vim
+++ b/autoload/wilder/renderer/wildmenu_float_or_popup.vim
@@ -73,6 +73,7 @@ endfunction
 
 function! s:pre_hook(state, ctx) abort
   call a:state.api.new({
+        \ 'zindex': get(a:state, 'zindex', v:null),
         \ 'normal_highlight': a:state.highlights.default,
         \ })
   call a:state.api.show()


### PR DESCRIPTION
Oops, seems like I broke the `wildmenu_float_or_popup` renderer by making `zindex` default to 0. (#103)

This occurs when I use `wilder#wildmenu_renderer`.

```
Error detected while processing function <lambda>193[1]..<SNR>155__open_win:
line   22:
E5555: API call: 'zindex' key must be a positive Integer
```

Feel free to make changes to my branch; I'm still very green when it comes to VimL scripting.