### PR TITLE
Fix parsing `arg` for user commands

### DIFF
--- a/autoload/wilder/cmdline/main.vim
+++ b/autoload/wilder/cmdline/main.vim
@@ -667,6 +667,9 @@ function! wilder#cmdline#main#do(ctx) abort
   elseif a:ctx.cmd ==# 'lua'
     let a:ctx.expand = 'lua'
     return
+  else
+    call s:move_pos_to_last_arg(a:ctx)
+    return
   endif
 endfunction
 


### PR DESCRIPTION
For user commands, the parsed `arg` was everything in the cmdline after the command name. This meant that for `:DiffviewOpen origin/master --i`, the `arg` was `origin/master --i`. The completions returned by `getcompletion(cmdline, 'cmdline')` returned the completions that are prefixed by the last argument (`--i`, for example `--imply-local`). Then, the filtering code attempted to filter the completions (`["--imply-local"]`) using `origin/master --i`, which did not match. For the `arg`, only the last argument (`--i`) should be used in this case for the filtering to return the correct completions.

The consequence was that completions for the 2nd and subsequent were not shown for user commands with `complete` functions in Lua.

This commit changes the cmdline parsing logic so that for user commands, only the last argument in the cmdline is parsed as the `arg`. This way the filtering logic correctly matches `--imply-local` as a valid completion for `--i`.

The following commands now show completions, whereas they did not show any completions before:

* :DiffviewOpen origin/master --i
* :Telescope live_grep pre


https://user-images.githubusercontent.com/889383/202699241-e02e7eac-854a-4597-8e9e-858f0f9bc232.mp4

![image](https://user-images.githubusercontent.com/889383/202699302-b92cfbd4-fe86-485e-ac2c-1f3b087e8bc4.png)

I didn't notice anything break at first sight. Completions for other types of commands seems to be working.

Fixes #159