### PR TITLE
Fix Unknown command in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,9 +1048,9 @@ wilder.set_option('pipeline', {
     wilder.python_file_finder_pipeline({
       file_command = function(ctx, arg)
         if string.find(arg, '.') ~= nil then
-          return {'fdfind', '-tf', '-H'}
+          return {'fd', '-tf', '-H'}
         else
-          return {'fdfind', '-tf'}
+          return {'fd', '-tf'}
         end
       end,
       dir_command = {'fd', '-td'},


### PR DESCRIPTION
copying the example directly kept throwing an error `No such File or Directory` when passing `fdfind` as the find command.