### PR TITLE
Fix autocmd BufEnter by loading buffer after setting nofile

### DIFF
--- a/autoload/wilder/renderer/vim_api.vim
+++ b/autoload/wilder/renderer/vim_api.vim
@@ -62,12 +62,13 @@ function! s:new_buf() abort
   set shortmess+=F
 
   let l:buf = bufadd('[Wilder Popup ' . s:index . ']')
-  call bufload(l:buf)
 
   call setbufvar(l:buf, '&buftype', 'nofile')
   call setbufvar(l:buf, '&bufhidden', 'hide')
   call setbufvar(l:buf, '&swapfile', 0)
   call setbufvar(l:buf, '&undolevels', -1)
+
+  call bufload(l:buf)
 
   let &shortmess = l:old_shortmess
 


### PR DESCRIPTION
For non-wilder vimrc that autocmd BufEnter (maybe more?) but opt to
filter out based off buftype will try to operate on wilder's buffer
during first open due to nofile being set after bufload.
